### PR TITLE
Handle kb interrupts gracefully

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -117,7 +117,11 @@ def main(argv=None):
     os.makedirs(bazel_directory, exist_ok=True)
     bazel_path = download_bazel_into_directory(bazel_version, bazel_directory)
 
-    return subprocess.Popen([bazel_path] + argv[1:], close_fds=True).wait()
+    p = subprocess.Popen([bazel_path] + argv[1:], close_fds=True)
+    try:
+        return p.wait()
+    except KeyboardInterrupt:
+        return p.wait()
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Before this, if you’re doing something like runinng tests and
then hit ctrl-c, the python dies first, and then the still-running
bazel process continues to write things to stdout until it exits itself.

Note that this bug only affected osx. on linux the behavior upon
ctrl-c was identical to a non-bazelisk invocation of bazel. after this
change, behavior upon ctrl-c is identical to a non-bazelisk
invocation of bazel, for both osx and linux.