### PR TITLE
Fixed searching of workspace on Windows.

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -47,7 +48,7 @@ func findWorkspaceRoot(root string) string {
 		return root
 	}
 
-	parentDirectory := path.Dir(root)
+	parentDirectory := filepath.Dir(root)
 	if parentDirectory == root {
 		return ""
 	}


### PR DESCRIPTION
On Windows Bazelisk previously only read `.bazelversion` if you are in the same directory.
@philwo 
