### PR TITLE
Support 'last_rc' in Bazelisk [Go-only]

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,7 @@ sh_test(
     srcs = ["bazelisk_test.sh"],
     data = ["bazelisk.py", "releases_for_tests.json"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
+    args = ["PY"]
 )
 
 sh_test(
@@ -16,6 +17,7 @@ sh_test(
     srcs = ["bazelisk_test.sh"],
     data = [":bazelisk", "releases_for_tests.json"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
+    args = ["GO"]
 )
 
 go_library(

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Bazelisk currently understands the following formats for version labels:
   be a release candidate version like `0.20.0rc3`.
 - `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel). Ideally this binary should be very close to Bazel-at-head.
 - `last_downstream_green` points to the most recent Bazel binary that builds and tests all [downstream projects](https://buildkite.com/bazel/bazel-at-head-plus-downstream) successfully.
+- `last_rc` points to the most recent release candidate. If there is no active release candidate, Bazelisk uses the latest Bazel release instead. Currently only the Go version of Bazelisk supports this value.
 
 
-In the future I will add support for release candidates and for building Bazel from source at a given commit.
+In the future I will add support for building Bazel from source at a given commit.
 
 ## Other features
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -36,6 +36,9 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
+BAZELISK_VERSION=$1
+shift 1
+
 function setup() {
   BAZELISK_HOME="$(mktemp -d $TEST_TMPDIR/home.XXXXXX)"
 
@@ -162,6 +165,8 @@ echo "# test_bazel_last_downstream_green"
 test_bazel_last_downstream_green
 echo
 
+if [[$BAZELISK_VERSION == "GO"]]; then
 echo "# test_bazel_last_rc"
 test_bazel_last_rc
 echo
+fi

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -127,6 +127,17 @@ function test_bazel_last_downstream_green() {
       (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
 }
 
+function test_bazel_last_rc() {
+  setup
+
+  USE_BAZEL_VERSION="last_rc" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  grep "Build label:" log || \
+      (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
+}
+
 echo "# test_bazel_version"
 test_bazel_version
 echo
@@ -149,4 +160,8 @@ echo
 
 echo "# test_bazel_last_downstream_green"
 test_bazel_last_downstream_green
+echo
+
+echo "# test_bazel_last_rc"
+test_bazel_last_rc
 echo


### PR DESCRIPTION
This commit introduces the "last_rc" version marker that makes Bazelisk use the most recent Bazel release candidate. If there is no active candidate, Bazelisk uses the latest release instead.

Currently this features is only supported in the Go version of Bazelisk, but not in the Python version.