### PR TITLE
Print bazelisk version formation when running 'bazel version'

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ go_library(
     importpath = "github.com/philwo/bazelisk",
     visibility = ["//visibility:private"],
     deps = ["@com_github_hashicorp_go_version//:go_default_library"],
+    x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
 )
 
 go_binary(

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -641,7 +641,21 @@ func main() {
 	// print bazelisk version information if "version" is the first argument
 	// bazel version is executed after this command
 	if len(args) > 0 && args[0] == "version" {
-		fmt.Printf("Bazelisk version: %s\n", BazeliskVersion)
+		// Check if the --gnu_format flag is set, if that is the case,
+		// the version is printed differently
+		var gnuFormat bool
+		for _, arg := range args {
+			if arg == "--gnu_format" {
+				gnuFormat = true
+				break
+			}
+		}
+
+		if gnuFormat {
+			fmt.Printf("Bazelisk %s\n", BazeliskVersion)
+		} else {
+			fmt.Printf("Bazelisk version: %s\n", BazeliskVersion)
+		}
 	}
 
 	exitCode, err := runBazel(bazelPath, args)

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -42,6 +42,10 @@ const (
 	wrapperPath = "./tools/bazel"
 )
 
+var (
+	BazeliskVersion = "development"
+)
+
 func findWorkspaceRoot(root string) string {
 	if _, err := os.Stat(filepath.Join(root, "WORKSPACE")); err == nil {
 		return root
@@ -632,6 +636,12 @@ func main() {
 			// that should be enabled for the given Bazel version.
 			args = insertArgs(args[1:], newFlags)
 		}
+	}
+
+	// print bazelisk version information if "version" is the first argument
+	// bazel version is executed after this command
+	if len(args) > 0 && args[0] == "version" {
+		fmt.Printf("Bazelisk version: %s\n", BazeliskVersion)
 	}
 
 	exitCode, err := runBazel(bazelPath, args)

--- a/stamp.sh
+++ b/stamp.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Use the first tag that points to the current HEAD
+# if no tag is found, the latest git commit is used as a fallback
+
+CURRENT_TAG=$(git tag -l --points-at HEAD | head -n1)
+CURRENT_COMMIT=$(git rev-parse HEAD)
+
+echo "STABLE_VERSION ${CURRENT_TAG:-$CURRENT_COMMIT}"


### PR DESCRIPTION
The version information is detected from git tags, with a fallback
to the latest git commit.

Fixes #65