### PR TITLE
Fix #61: Do not execute tools/bazel when BAZELISK_SKIP_WRAPPER is set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ show you which flags can safely enabled, and which flags require a migration.
 You can set `BAZELISK_GITHUB_TOKEN` to set a GitHub access token to use for API
 requests to avoid rate limiting when on shared networks.
 
+If `tools/bazel` exists in your workspace root and is executable, Bazelisk will run this file,
+instead of the Bazel version it downloaded. It will set the environment variable `BAZEL_REAL` to
+the path of the downloaded Bazel binary. This can be useful, if you have a wrapper script that e.g.
+ensures that environment variables are set to known good values. This behavior can be disabled by
+setting the environment variable `BAZELISK_SKIP_WRAPPER` to any value (except the empty string)
+before launching Bazelisk.
+
 ## Releases
 
 Binary and source releases are provided on our [Releases](https://github.com/bazelbuild/bazelisk/releases) page.

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -61,6 +61,7 @@ function bazelisk() {
   else
     echo "Could not find the bazelisk executable, listing files:"
     find .
+    exit 1
   fi
 }
 
@@ -141,6 +142,49 @@ function test_bazel_last_rc() {
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
+function test_delegate_to_wrapper() {
+  setup
+
+  mkdir tools
+  cat > tools/bazel <<'EOF'
+#!/bin/sh
+echo HELLO_WRAPPER
+env | grep BAZELISK_SKIP_WRAPPER
+EOF
+  chmod +x tools/bazel
+
+  BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  grep "HELLO_WRAPPER" log || \
+      (echo "FAIL: Expected to find 'HELLO_WRAPPER' in the output of 'bazelisk version'"; exit 1)
+
+  grep "BAZELISK_SKIP_WRAPPER=true" log || \
+      (echo "FAIL: Expected to find 'BAZELISK_SKIP_WRAPPER=true' in the output of 'bazelisk version'"; exit 1)
+}
+
+function test_skip_wrapper() {
+  setup
+
+  mkdir tools
+  cat > tools/bazel <<'EOF'
+#!/bin/sh
+echo HELLO_WRAPPER
+env | grep BAZELISK_SKIP_WRAPPER
+EOF
+  chmod +x tools/bazel
+
+  BAZELISK_HOME="$BAZELISK_HOME" \
+      BAZELISK_SKIP_WRAPPER="true" \
+      bazelisk version 2>&1 | tee log
+
+  grep "HELLO_WRAPPER" log && \
+      (echo "FAIL: Expected to not find 'HELLO_WRAPPER' in the output of 'bazelisk version'"; exit 1)
+
+  grep "Build label:" log || \
+      (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
+}
+
 echo "# test_bazel_version"
 test_bazel_version
 echo
@@ -165,8 +209,16 @@ echo "# test_bazel_last_downstream_green"
 test_bazel_last_downstream_green
 echo
 
-if [[$BAZELISK_VERSION == "GO"]]; then
-echo "# test_bazel_last_rc"
-test_bazel_last_rc
-echo
+if [[ $BAZELISK_VERSION == "GO" ]]; then
+  echo "# test_bazel_last_rc"
+  test_bazel_last_rc
+  echo
+
+  echo "# test_delegate_to_wrapper"
+  test_delegate_to_wrapper
+  echo
+
+  echo "# test_skip_wrapper"
+  test_skip_wrapper
+  echo
 fi

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -214,11 +214,18 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
   test_bazel_last_rc
   echo
 
-  echo "# test_delegate_to_wrapper"
-  test_delegate_to_wrapper
-  echo
+  case "$(uname -s)" in
+    MSYS*)
+      # The tests are currently not compatible with Windows.
+      ;;
+    *)
+      echo "# test_delegate_to_wrapper"
+      test_delegate_to_wrapper
+      echo
 
-  echo "# test_skip_wrapper"
-  test_skip_wrapper
-  echo
+      echo "# test_skip_wrapper"
+      test_skip_wrapper
+      echo
+      ;;
+  esac
 fi

--- a/build.sh
+++ b/build.sh
@@ -38,4 +38,5 @@ rm -f bazelisk
 # GOOS=windows GOARCH=amd64 go build -o bin/bazelisk-windows-amd64.exe
 
 ### Print some information about the generated binaries.
+ls -lh bin/*
 file bin/*


### PR DESCRIPTION
Bazelisk will set this environment variable when executing Bazel (or
a wrapper found in <workspace_root>/tools/bazel). This prevents Bazelisk
from executing itself in an infinite loop, in case the wrapper is
Bazelisk or somehow executes Bazelisk.

If you're using a wrapper in <workspace_root>/tools/bazel that downloads
Bazelisk and delegates to it, please set the BAZELISK_SKIP_WRAPPER
environment variable to ensure that Bazelisk directly executes Bazel.