### PR TITLE
Fix empty .bazelversion download error

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -98,7 +98,9 @@ func getBazelVersion() (string, error) {
 				return "", fmt.Errorf("could not read version from file %s: %v", bazelVersion, err)
 			}
 
-			return bazelVersion, nil
+			if len(bazelVersion) != 0 {
+				return bazelVersion, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix the download error if there is an empty `.bazelversion`.

It would be useful and more robust when users temporarily need the latest version of Bazel, but they don't need to remove `.bazelversion`.