### PR TITLE
Allow using local Bazel binaries.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,7 +43,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk",
     visibility = ["//visibility:private"],
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
-    deps = ["@com_github_hashicorp_go_version//:go_default_library"],
+    deps = [
+        "@com_github_hashicorp_go_version//:go_default_library",
+        "@com_github_mitchellh_go_homedir//:go_default_library",
+    ],
 )
 
 go_binary(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,3 +34,10 @@ go_repository(
     sum = "h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=",
     version = "v1.1.0",
 )
+
+go_repository(
+    name = "com_github_mitchellh_go_homedir",
+    importpath = "github.com/mitchellh/go-homedir",
+    sum = "h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=",
+    version = "v1.1.0",
+)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/bazelbuild/bazelisk
 
-require github.com/hashicorp/go-version v1.1.0
+require (
+	github.com/hashicorp/go-version v1.1.0
+	github.com/mitchellh/go-homedir v1.1.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
Bazel versions (e.g. in USE_BAZEL_VERSION or .bazelversion) can now
refer to absolute paths on the filesystem. As an added convenience, a
tilde prefix is expanded to the user's home directory.

Example:

```sh
$ USE_BAZEL_VERSION="~/bin/bazel-1.0" bazelisk
```

This would tell Bazelisk to not download any binaries and instead
just directly use the Bazel binary in `$HOME/bin/bazel-1.0`.