### PR TITLE
bazelisk_test.sh: Unset USE_BAZEL_VERSION in setup

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -40,6 +40,7 @@ BAZELISK_VERSION=$1
 shift 1
 
 function setup() {
+  unset USE_BAZEL_VERSION
   BAZELISK_HOME="$(mktemp -d $TEST_TMPDIR/home.XXXXXX)"
 
   cp "$(rlocation __main__/releases_for_tests.json)" "${BAZELISK_HOME}/bazelbuild-releases.json"


### PR DESCRIPTION
Fix Bazelisk failure in Bazel CI Downstream after we always pass --test_env=USE_BAZEL_VERSION for all tests.

Fixing https://github.com/bazelbuild/bazel/issues/10024