### PR TITLE
Support WORKSPACE.bazel file

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -54,6 +54,10 @@ func findWorkspaceRoot(root string) string {
 		return root
 	}
 
+	if _, err := os.Stat(filepath.Join(root, "WORKSPACE.bazel")); err == nil {
+		return root
+	}
+
 	parentDirectory := filepath.Dir(root)
 	if parentDirectory == root {
 		return ""


### PR DESCRIPTION
When finding workspace root, also check the existence of WORKSPACE.bazel
file. Bazel supports WOKRSPACE.bazel file from 1.2.

Related https://github.com/bazelbuild/bazel/pull/10175