### PR TITLE
add support to providing custom url for downloading the binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A version can optionally be prefixed with a fork name.
 The fork and version should be separated by slash: `<FORK>/<VERSION>`.
 If you want to create a fork with your own releases, you have to follow the naming conventions that we use in `bazelbuild/bazel` for the binary file names.
 The URL format looks like `https://github.com/<FORK>/bazel/releases/download/<VERSION>/<FILENAME>`.
+You can also override the url by setting `BAZELISK_BASE_URL`.
 
 Bazelisk currently understands the following formats for version labels:
 - `latest` means the latest stable version of Bazel as released on GitHub.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ A version can optionally be prefixed with a fork name.
 The fork and version should be separated by slash: `<FORK>/<VERSION>`.
 If you want to create a fork with your own releases, you have to follow the naming conventions that we use in `bazelbuild/bazel` for the binary file names.
 The URL format looks like `https://github.com/<FORK>/bazel/releases/download/<VERSION>/<FILENAME>`.
-You can also override the url by setting `BAZELISK_BASE_URL`.
+
+You can also override the URL by setting the environment variable `$BAZELISK_BASE_URL`. Bazelisk will then append `/<VERSION>/<FILENAME>` to the base URL instead of using the official release server.
 
 Bazelisk currently understands the following formats for version labels:
 - `latest` means the latest stable version of Bazel as released on GitHub.

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -43,6 +43,7 @@ const (
 	skipWrapperEnv = "BAZELISK_SKIP_WRAPPER"
 	wrapperPath    = "./tools/bazel"
 	bazelUpstream  = "bazelbuild"
+	githubUpstream = "https://github.com/%s/bazel/releases/download"
 )
 
 var (
@@ -388,6 +389,11 @@ func determineURL(fork string, version string, isCommit bool, filename string) s
 		return fmt.Sprintf("https://storage.googleapis.com/bazel-builds/artifacts/%s/%s/bazel", platforms[runtime.GOOS], version)
 	}
 
+	baseURL := os.Getenv("BAZELISK_BASE_URL")
+	if len(baseURL) == 0 {
+		baseURL = githubUpstream
+	}
+
 	kind := "release"
 	if strings.Contains(version, "rc") {
 		versionComponents := strings.Split(version, "rc")
@@ -396,11 +402,16 @@ func determineURL(fork string, version string, isCommit bool, filename string) s
 		kind = "rc" + versionComponents[1]
 	}
 
+	if baseURL != githubUpstream {
+		return fmt.Sprintf("%s/%s/%s", baseURL, version, filename)
+	}
+
 	if fork == bazelUpstream {
 		return fmt.Sprintf("https://releases.bazel.build/%s/%s/%s", version, kind, filename)
 	}
 
-	return fmt.Sprintf("https://github.com/%s/bazel/releases/download/%s/%s", fork, version, filename)
+	baseURL = fmt.Sprintf(githubUpstream, fork)
+	return fmt.Sprintf("%s/%s/%s", baseURL, version, filename)
 }
 
 func downloadBazel(fork string, version string, isCommit bool, directory string) (string, error) {

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -106,6 +106,19 @@ function test_bazel_version_from_file() {
       (echo "FAIL: Expected to find 'Build label: 0.19.0' in the output of 'bazelisk version'"; exit 1)
 }
 
+function test_bazel_version_from_url() {
+  setup
+
+  echo "0.19.0" > .bazelversion
+
+  BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+          bazelisk version 2>&1 | tee log
+
+  grep "Build label: 0.19.0" log || \
+      (echo "FAIL: Expected to find 'Build label: 0.19.0' in the output of 'bazelisk version'"; exit 1)
+}
+
 function test_bazel_latest_minus_3() {
   setup
 
@@ -220,6 +233,10 @@ echo
 if [[ $BAZELISK_VERSION == "GO" ]]; then
   echo "# test_bazel_last_rc"
   test_bazel_last_rc
+  echo
+
+  echo "# test_bazel_version_from_url"
+  test_bazel_version_from_url
   echo
 
   case "$(uname -s)" in


### PR DESCRIPTION
this is usefull to have for local networks. As long as the provided
url follows github release page format. For example, if you use
an artifactory repository and point it to github.

How it works is one can set `BAZELISK_BASE_URL` as long as that url follows the same pattern as github release page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/bazelisk/107)
<!-- Reviewable:end -->
