### PR TITLE
Make bazelisk available as "bazel" when installing via NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "version": "0.0.0-PLACEHOLDER",
     "license": "Apache-2.0",
     "bin": {
-        "bazelisk": "bazelisk.js"
+        "bazelisk": "bazelisk.js",
+        "bazel": "bazelisk.js"
     },
     "keywords": [
         "bazel"


### PR DESCRIPTION
Right now having to install bazelisk and then setup a symlink to it under e.g. `/usr/bin/bazel` is a bit annoying.

By adding this, a user can immediately start running `bazel` commands via bazelisk (as well as `bazelisk` commands) after doing:

```
npm i -g @bazel/bazelisk
```

This is the suggested way to use bazelisk in the readme, and for the nodejs users I struggle to see many scenarios where you wouldn't want this to happen.