### PR TITLE
make inferred workspace dir consistent with actual one in builds

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -53,7 +53,7 @@ BAZEL_GCS_PATH_PATTERN = (
 
 SUPPORTED_PLATFORMS = {"linux": "ubuntu1404", "windows": "windows", "darwin": "macos"}
 
-TOOLS_BAZEL_PATH = "./tools/bazel"
+TOOLS_BAZEL_PATH = "tools/bazel"
 
 BAZEL_REAL = "BAZEL_REAL"
 


### PR DESCRIPTION
I want to make the workspace path you get when you look at `$BUILD_WORKSPACE_DIRECTORY` inside the target you're running, be consistent with the value you get if you do `$(dirname "$(dirname "${BASH_SOURCE[0]}")")` in a `tools/bazel` script. I'm using the latter form of this as part of a startup option in my wrapper.

I am using the tools/bazel script to `$BAZEL_REAL run` the full wrapper target, which takes the rest of the args, does some logging, and invokes BAZEL_REAL again with the original args. But it also needs to set that startup option when it does so, to avoid thrashing the server. To do so it uses BUILD_WORKSPACE_DIRECTORY.

What I noticed is that it was thrashing the server anyway. When I dug in, it turned out the issue was that inside tools/bazel it was passing

```bash
--host_jvm_args=-Djavax.net.ssl.trustStore=/Users/geoff/proj/./cacerts`
```

But inside the target running via bazel run, it was passing

```bash
--host_jvm_args=-Djavax.net.ssl.trustStore=/Users/geoff/proj/cacerts`
```

Even though they're logically the same file, bazel doesn't realize that, especially when the path is being passed to an arbitrary JVM flag. So it restarts the server each time.

Removing the leading `./` in the constant prevents the server restarts, and seems safe because that constant is only ever used in `os.path.join()` which is aware of how to combine path components.

I also included a test to show the difference, but you can remove it if you think it's silly.