### PR TITLE
Retrieve Bazel versions from GCS if GitHub is down

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,16 @@ go_test(
     ],
 )
 
+go_test(
+    name = "go_version_test",
+    srcs = ["bazelisk_version_test.go"],
+    embed = [":go_default_library"],
+    importpath = "github.com/bazelbuild/bazelisk",
+    deps = [
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)
+
 go_binary(
     name = "bazelisk",
     embed = [":go_default_library"],

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Before Bazelisk was rewritten in Go, it was a Python script.
 This still works and has the advantage that you can run it on any platform that has a Python interpreter, but is currently unmaintained and it doesn't support as many features.
 The documentation below describes the newer Go version only.
 
-## How does Bazelisk know which Bazel version to run and where to get it from?
+## How does Bazelisk know which Bazel version to run?
 
 It uses a simple algorithm:
 - If the environment variable `USE_BAZEL_VERSION` is set, it will use the version specified in the value.
@@ -32,10 +32,7 @@ It uses a simple algorithm:
 
 A version can optionally be prefixed with a fork name.
 The fork and version should be separated by slash: `<FORK>/<VERSION>`.
-If you want to create a fork with your own releases, you have to follow the naming conventions that we use in `bazelbuild/bazel` for the binary file names.
-The URL format looks like `https://github.com/<FORK>/bazel/releases/download/<VERSION>/<FILENAME>`.
-
-You can also override the URL by setting the environment variable `$BAZELISK_BASE_URL`. Bazelisk will then append `/<VERSION>/<FILENAME>` to the base URL instead of using the official release server.
+Please see the next section for how to work with forks.
 
 Bazelisk currently understands the following formats for version labels:
 - `latest` means the latest stable version of Bazel as released on GitHub.
@@ -49,6 +46,18 @@ Additionally, a few special version names are supported for our official release
 - `last_downstream_green` points to the most recent Bazel binary that builds and tests all [downstream projects](https://buildkite.com/bazel/bazel-at-head-plus-downstream) successfully.
 - `last_rc` points to the most recent release candidate.
   If there is no active release candidate, Bazelisk uses the latest Bazel release instead.
+
+## Where does Bazelisk get Bazel from?
+
+By default Bazelisk retrieves the list of Bazel versions from the Bazel GitHub project. If this fails, Bazelisk queries the official Bazel release server instead.
+In both cases the actual binaries are downloaded from the release server.
+
+As mentioned in the previous section, the `<FORK>/<VERSION>` version format allows you to use your own Bazel fork instead of working with the official servers:
+
+If you want to create a fork with your own releases, you have to follow the naming conventions that we use in `bazelbuild/bazel` for the binary file names.
+The URL format looks like `https://github.com/<FORK>/bazel/releases/download/<VERSION>/<FILENAME>`.
+
+You can also override the URL by setting the environment variable `$BAZELISK_BASE_URL`. Bazelisk will then append `/<VERSION>/<FILENAME>` to the base URL instead of using the official release server.
 
 ## Other features
 

--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+var (
+	transport = &fakeTransport{responses: make(map[string]*http.Response)}
+	tmpDir    = ""
+)
+
+func init() {
+	DefaultTransport = transport
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	tmpDir, err = ioutil.TempDir("", "version_test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestResolveLatestVersion_UseGCSIfBazelGitHubIsDown_NoRC(t *testing.T) {
+	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
+
+	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "12.0.0/", "10.0.0/"}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
+
+	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{"this is a release"})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=12.0.0/release/", 200, rcBody)
+
+	version, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
+
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	if version != "12.0.0" {
+		t.Fatalf("Expected version 12.0.0, but got %s", version)
+	}
+}
+
+func TestResolveLatestVersion_UseGCSIfBazelGitHubIsDown_WithRC(t *testing.T) {
+	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
+
+	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "11.0.0/", "11.11.0/", "10.0.0/"}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
+
+	// 11.11.0 is the current RC, but the latest release is still 11.0.0
+	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/release/", 200, rcBody)
+
+	version, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	if version != "11.0.0" {
+		t.Fatalf("Expected version 11.0.0, but got %s", version)
+	}
+}
+
+func TestResolveLatestRcVersion(t *testing.T) {
+	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "11.0.0/", "11.11.0/", "10.0.0/"}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
+
+	rcListBody := buildGCSResponseOrFail(t, []string{"11.11.0/rc2/", "11.11.0/rc1/"}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/", 200, rcListBody)
+
+	// 11.11.0 is the current RC, but the latest release is still 11.0.0
+	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{})
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/release/", 200, rcBody)
+
+	version, err := resolveLatestRcVersion()
+
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	expectedRC := "11.11.0rc2"
+	if version != expectedRC {
+		t.Fatalf("Expected version %s, but got %s", expectedRC, version)
+	}
+}
+
+func TestResolveLatestVersion_EverythingIsDown(t *testing.T) {
+	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
+	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 500, "")
+
+	_, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
+
+	if err == nil {
+		t.Fatal("Expected resolveLatestVersion() to fail.")
+	}
+	expectedPrefix := "could not list Bazel versions in GCS bucket"
+	if !strings.HasPrefix(err.Error(), expectedPrefix) {
+		t.Fatalf("Expected error message that starts with '%s', but got '%v'", expectedPrefix, err)
+	}
+}
+
+func TestResolveLatestVersion_NoFallbackIfGitHubForkIsDown(t *testing.T) {
+	transport.AddResponse("https://api.github.com/repos/the_fork/bazel/releases", 500, "")
+
+	_, err := resolveLatestVersion(tmpDir, "the_fork", 0)
+
+	if err == nil {
+		t.Fatal("Expected resolveLatestVersion() to fail.")
+	}
+	expectedSubstring := "github.com/the_fork/bazel"
+	if !strings.Contains(err.Error(), expectedSubstring) {
+		t.Fatalf("Expected error message that contains '%s', but got '%v'", expectedSubstring, err)
+	}
+}
+
+type fakeTransport struct {
+	responses map[string]*http.Response
+}
+
+func (ft *fakeTransport) AddResponse(url string, status int, body string) {
+	ft.responses[url] = ft.createResponse(status, body)
+}
+
+func (ft *fakeTransport) createResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func (ft *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if resp, ok := ft.responses[req.URL.String()]; ok {
+		return resp, nil
+	}
+	return ft.createResponse(http.StatusNotFound, ""), nil
+}
+
+func buildGCSResponseOrFail(t *testing.T, prefixes []string, items []interface{}) string {
+	r := &gcsListResponse{
+		Prefixes: prefixes,
+		Items:    items,
+	}
+	if bytes, err := json.Marshal(r); err != nil {
+		t.Fatalf("Could not build GCS json response: %v", err)
+		return ""
+	} else {
+		return string(bytes)
+	}
+}


### PR DESCRIPTION
This fallback strategy is NOT executed when users specify a fork of Bazel. In this case the version resolution algorithm fails immediately.

Note: This change only affects the origin of Bazel's version history. For upstream Bazel all binaries are downloaded from GCS, which has already been the case before this change.

Fixes #87