### PR TITLE
Also check if `tools/bazel` is a directory

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -632,7 +632,7 @@ func maybeDelegateToWrapper(bazel string) string {
 
 	root := findWorkspaceRoot(wd)
 	wrapper := filepath.Join(root, wrapperPath)
-	if stat, err := os.Stat(wrapper); err != nil || stat.Mode().Perm()&0001 == 0 {
+	if stat, err := os.Stat(wrapper); err != nil || stat.IsDir() || stat.Mode().Perm()&0001 == 0 {
 		return bazel
 	}
 


### PR DESCRIPTION
If `tools/bazel` is a directory, the `maybeDelegateToWrapper` function tries to execute it, which results in a permission denied error.

This commit prevents that by checking if `tools/bazel` is a directory and ignores it.