### PR TITLE
Refactor Bazel version retrieval & downloads

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -47,6 +47,11 @@ go_library(
     deps = [
         "@com_github_hashicorp_go_version//:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
+        "//core",
+        "//httputil",
+        "//platforms",
+        "//repositories",
+        "//versions",
     ],
 )
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Bazelisk currently understands the following formats for version labels:
   Previous releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel.
   It can also be a release candidate version like `0.20.0rc3`.
+- The hash of a Git commit. Please note that Bazel binaries are only available for commits that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).
 
 Additionally, a few special version names are supported for our official releases only (these formats do not work when using a fork):
 - `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -532,6 +532,7 @@ func dirForURL(url string) string {
 	return regexp.MustCompile("[[:^alnum:]]").ReplaceAllString(url, "-")
 }
 
+// RunBazelisk runs the main Bazelisk logic for the given arguments and Bazel repositories.
 func RunBazelisk(args []string, repos *core.Repositories) (int, error) {
 	bazeliskHome := getEnvOrConfig("BAZELISK_HOME")
 	if len(bazeliskHome) == 0 {

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -275,7 +275,7 @@ function test_bazel_download_path_go() {
 
   find "$BAZELISK_HOME/downloads/bazelbuild" 2>&1 | tee log
 
-  grep "^$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9]+.[0-9]+.[0-9]+-[a-z0-9_-]*/bin/bazel\(.exe\)\?$" log || \
+  grep "^$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*-[a-z0-9_-]*/bin/bazel\(.exe\)\?$" log || \
       (echo "FAIL: Expected to download bazel binary into specific path."; exit 1)
 }
 
@@ -297,7 +297,7 @@ function test_bazel_prepend_binary_directory_to_path_go() {
   BAZELISK_HOME="$BAZELISK_HOME" \
       bazelisk --print_env 2>&1 | tee log
 
-  PATTERN=$(echo "^PATH=$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9]+.[0-9]+.[0-9]+-[a-z0-9_-]*/bin[:;]" | sed -e 's/\//\[\/\\\\\]/g')
+  PATTERN=$(echo "^PATH=$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*-[a-z0-9_-]*/bin[:;]" | sed -e 's/\//\[\/\\\\\]/g')
   grep "$PATTERN" log || \
       (echo "FAIL: Expected PATH to contains bazel binary directory."; exit 1)
 }
@@ -362,7 +362,7 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
   test_bazel_download_path_go
   echo
 
-  echo "# test_bazel_prepend_binary_directory_to_path"
+  echo "# test_bazel_prepend_binary_directory_to_path_go"
   test_bazel_prepend_binary_directory_to_path_go
   echo
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -39,6 +39,8 @@ fi
 BAZELISK_VERSION=$1
 shift 1
 
+# TODO: only the Python version reads bazelbuild-releases.json since it uses
+# GitHub by default, whereas the Go version GCS (without this json file)
 function setup() {
   unset USE_BAZEL_VERSION
   BAZELISK_HOME="$(mktemp -d $TEST_TMPDIR/home.XXXXXX)"
@@ -73,13 +75,23 @@ function bazelisk() {
   fi
 }
 
-function test_bazel_version() {
+function test_bazel_version_py() {
   setup
 
   BAZELISK_HOME="$BAZELISK_HOME" \
       bazelisk version 2>&1 | tee log
 
   grep "Build label: 0.21.0" log || \
+      (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
+}
+
+function test_bazel_version_go() {
+  setup
+
+  BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  grep "Build label: " log || \
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
@@ -157,7 +169,7 @@ function test_bazel_version_from_url() {
       (echo "FAIL: Expected to find 'Build label: 0.19.0' in the output of 'bazelisk version'"; exit 1)
 }
 
-function test_bazel_latest_minus_3() {
+function test_bazel_latest_minus_3_py() {
   setup
 
   USE_BAZEL_VERSION="latest-3" \
@@ -165,6 +177,17 @@ function test_bazel_latest_minus_3() {
       bazelisk version 2>&1 | tee log
 
   grep "Build label: 0.19.1" log || \
+      (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
+}
+
+function test_bazel_latest_minus_3_go() {
+  setup
+
+  USE_BAZEL_VERSION="latest-3" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  grep "Build label: " log || \
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
@@ -244,7 +267,19 @@ EOF
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
-function test_bazel_download_path() {
+function test_bazel_download_path_go() {
+  setup
+
+  BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  find "$BAZELISK_HOME/downloads/bazelbuild" 2>&1 | tee log
+
+  grep "^$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9]+.[0-9]+.[0-9]+-[a-z0-9_-]*/bin/bazel\(.exe\)\?$" log || \
+      (echo "FAIL: Expected to download bazel binary into specific path."; exit 1)
+}
+
+function test_bazel_download_path_py() {
   setup
 
   BAZELISK_HOME="$BAZELISK_HOME" \
@@ -256,7 +291,18 @@ function test_bazel_download_path() {
       (echo "FAIL: Expected to download bazel binary into specific path."; exit 1)
 }
 
-function test_bazel_prepend_binary_directory_to_path() {
+function test_bazel_prepend_binary_directory_to_path_go() {
+  setup
+
+  BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk --print_env 2>&1 | tee log
+
+  PATTERN=$(echo "^PATH=$BAZELISK_HOME/downloads/bazelbuild/bazel-[0-9]+.[0-9]+.[0-9]+-[a-z0-9_-]*/bin[:;]" | sed -e 's/\//\[\/\\\\\]/g')
+  grep "$PATTERN" log || \
+      (echo "FAIL: Expected PATH to contains bazel binary directory."; exit 1)
+}
+
+function test_bazel_prepend_binary_directory_to_path_py() {
   setup
 
   BAZELISK_HOME="$BAZELISK_HOME" \
@@ -267,20 +313,12 @@ function test_bazel_prepend_binary_directory_to_path() {
       (echo "FAIL: Expected PATH to contains bazel binary directory."; exit 1)
 }
 
-echo "# test_bazel_version"
-test_bazel_version
-echo
-
 echo "# test_bazel_version_from_environment"
 test_bazel_version_from_environment
 echo
 
 echo "# test_bazel_version_from_file"
 test_bazel_version_from_file
-echo
-
-echo "# test_bazel_latest_minus_3"
-test_bazel_latest_minus_3
 echo
 
 echo "# test_bazel_last_green"
@@ -291,15 +329,15 @@ echo "# test_bazel_last_downstream_green"
 test_bazel_last_downstream_green
 echo
 
-echo '# test_bazel_download_path'
-test_bazel_download_path
-echo
-
-echo "# test_bazel_prepend_binary_directory_to_path"
-test_bazel_prepend_binary_directory_to_path
-echo
-
 if [[ $BAZELISK_VERSION == "GO" ]]; then
+  echo "# test_bazel_version_go"
+  test_bazel_version_go
+  echo
+
+  echo "# test_bazel_latest_minus_3_go"
+  test_bazel_latest_minus_3_go
+  echo
+
   echo "# test_bazel_last_rc"
   test_bazel_last_rc
   echo
@@ -320,6 +358,14 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
   test_bazel_version_prefer_bazeliskrc_to_bazelversion_file
   echo
 
+  echo '# test_bazel_download_path_go'
+  test_bazel_download_path_go
+  echo
+
+  echo "# test_bazel_prepend_binary_directory_to_path"
+  test_bazel_prepend_binary_directory_to_path_go
+  echo
+
   case "$(uname -s)" in
     MSYS*)
       # The tests are currently not compatible with Windows.
@@ -334,4 +380,20 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
       echo
       ;;
   esac
+else
+  echo "# test_bazel_version_py"
+  test_bazel_version_py
+  echo
+
+  echo "# test_bazel_latest_minus_3_py"
+  test_bazel_latest_minus_3_py
+  echo
+
+  echo '# test_bazel_download_path_py'
+  test_bazel_download_path_py
+  echo
+
+  echo "# test_bazel_prepend_binary_directory_to_path_py"
+  test_bazel_prepend_binary_directory_to_path_py
+  echo
 fi

--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -9,6 +9,10 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/bazelbuild/bazelisk/core"
+	"github.com/bazelbuild/bazelisk/httputil"
+	"github.com/bazelbuild/bazelisk/repositories"
 )
 
 var (
@@ -17,7 +21,7 @@ var (
 )
 
 func init() {
-	DefaultTransport = transport
+	httputil.DefaultTransport = transport
 }
 
 func TestMain(m *testing.M) {
@@ -32,44 +36,6 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestResolveLatestVersion_UseGCSIfBazelGitHubIsDown_NoRC(t *testing.T) {
-	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
-
-	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "12.0.0/", "10.0.0/"}, []interface{}{})
-	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
-
-	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{"this is a release"})
-	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=12.0.0/release/", 200, rcBody)
-
-	version, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
-
-	if err != nil {
-		t.Fatalf("Version resolution failed unexpectedly: %v", err)
-	}
-	if version != "12.0.0" {
-		t.Fatalf("Expected version 12.0.0, but got %s", version)
-	}
-}
-
-func TestResolveLatestVersion_UseGCSIfBazelGitHubIsDown_WithRC(t *testing.T) {
-	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
-
-	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "11.0.0/", "11.11.0/", "10.0.0/"}, []interface{}{})
-	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
-
-	// 11.11.0 is the current RC, but the latest release is still 11.0.0
-	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{})
-	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/release/", 200, rcBody)
-
-	version, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
-	if err != nil {
-		t.Fatalf("Version resolution failed unexpectedly: %v", err)
-	}
-	if version != "11.0.0" {
-		t.Fatalf("Expected version 11.0.0, but got %s", version)
-	}
-}
-
 func TestResolveLatestRcVersion(t *testing.T) {
 	listBody := buildGCSResponseOrFail(t, []string{"4.0.0/", "11.0.0/", "11.11.0/", "10.0.0/"}, []interface{}{})
 	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 200, listBody)
@@ -81,7 +47,9 @@ func TestResolveLatestRcVersion(t *testing.T) {
 	rcBody := buildGCSResponseOrFail(t, []string{}, []interface{}{})
 	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/release/", 200, rcBody)
 
-	version, err := resolveLatestRcVersion()
+	gcs := &repositories.GCSRepo{}
+
+	version, err := resolveLatestRcVersion(tmpDir, gcs)
 
 	if err != nil {
 		t.Fatalf("Version resolution failed unexpectedly: %v", err)
@@ -92,32 +60,37 @@ func TestResolveLatestRcVersion(t *testing.T) {
 	}
 }
 
-func TestResolveLatestVersion_EverythingIsDown(t *testing.T) {
-	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
+func TestResolveLatestVersion_GCSIsDown(t *testing.T) {
 	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/", 500, "")
 
-	_, err := resolveLatestVersion(tmpDir, bazelUpstream, 0)
+	gcs := &repositories.GCSRepo{}
+	repos := core.CreateRepositories(gcs, nil, nil, nil, false)
+
+	_, err := resolveLatestVersion(tmpDir, core.BazelUpstream, 0, repos)
 
 	if err == nil {
 		t.Fatal("Expected resolveLatestVersion() to fail.")
 	}
-	expectedPrefix := "could not list Bazel versions in GCS bucket"
+	expectedPrefix := "unable to determine latest version: could not list Bazel versions in GCS bucket"
 	if !strings.HasPrefix(err.Error(), expectedPrefix) {
 		t.Fatalf("Expected error message that starts with '%s', but got '%v'", expectedPrefix, err)
 	}
 }
 
-func TestResolveLatestVersion_NoFallbackIfGitHubForkIsDown(t *testing.T) {
-	transport.AddResponse("https://api.github.com/repos/the_fork/bazel/releases", 500, "")
+func TestResolveLatestVersion_GitHubIsDown(t *testing.T) {
+	transport.AddResponse("https://api.github.com/repos/bazelbuild/bazel/releases", 500, "")
 
-	_, err := resolveLatestVersion(tmpDir, "the_fork", 0)
+	gh := repositories.CreateGitHubRepo("test_token")
+	repos := core.CreateRepositories(nil, nil, gh, nil, false)
+
+	_, err := resolveLatestVersion(tmpDir, "some_fork", 0, repos)
 
 	if err == nil {
 		t.Fatal("Expected resolveLatestVersion() to fail.")
 	}
-	expectedSubstring := "github.com/the_fork/bazel"
-	if !strings.Contains(err.Error(), expectedSubstring) {
-		t.Fatalf("Expected error message that contains '%s', but got '%v'", expectedSubstring, err)
+	expectedPrefix := "unable to determine latest version: unable to dermine 'some_fork' releases: could not download list of Bazel releases from github.com/some_fork"
+	if !strings.HasPrefix(err.Error(), expectedPrefix) {
+		t.Fatalf("Expected error message that starts with '%s', but got '%v'", expectedPrefix, err)
 	}
 }
 
@@ -144,7 +117,7 @@ func (ft *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func buildGCSResponseOrFail(t *testing.T, prefixes []string, items []interface{}) string {
-	r := &gcsListResponse{
+	r := &repositories.GcsListResponse{
 		Prefixes: prefixes,
 		Items:    items,
 	}

--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/httputil"
 	"github.com/bazelbuild/bazelisk/repositories"
+	"github.com/bazelbuild/bazelisk/versions"
 )
 
 var (
@@ -48,8 +49,8 @@ func TestResolveLatestRcVersion(t *testing.T) {
 	transport.AddResponse("https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/&prefix=11.11.0/release/", 200, rcBody)
 
 	gcs := &repositories.GCSRepo{}
-
-	version, err := resolveLatestRcVersion(tmpDir, gcs)
+	repos := core.CreateRepositories(nil, gcs, nil, nil, false)
+	version, _, err := repos.ResolveVersion(tmpDir, versions.BazelUpstream, "last_rc")
 
 	if err != nil {
 		t.Fatalf("Version resolution failed unexpectedly: %v", err)
@@ -65,8 +66,7 @@ func TestResolveLatestVersion_GCSIsDown(t *testing.T) {
 
 	gcs := &repositories.GCSRepo{}
 	repos := core.CreateRepositories(gcs, nil, nil, nil, false)
-
-	_, err := resolveLatestVersion(tmpDir, core.BazelUpstream, 0, repos)
+	_, _, err := repos.ResolveVersion(tmpDir, versions.BazelUpstream, "latest")
 
 	if err == nil {
 		t.Fatal("Expected resolveLatestVersion() to fail.")
@@ -83,7 +83,7 @@ func TestResolveLatestVersion_GitHubIsDown(t *testing.T) {
 	gh := repositories.CreateGitHubRepo("test_token")
 	repos := core.CreateRepositories(nil, nil, gh, nil, false)
 
-	_, err := resolveLatestVersion(tmpDir, "some_fork", 0, repos)
+	_, _, err := repos.ResolveVersion(tmpDir, "some_fork", "latest")
 
 	if err == nil {
 		t.Fatal("Expected resolveLatestVersion() to fail.")

--- a/core/BUILD
+++ b/core/BUILD
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//httputil",
         "//platforms",
+        "//versions",
     ],
 )

--- a/core/BUILD
+++ b/core/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "core",
+    srcs = ["repositories.go"],
+    importpath = "github.com/bazelbuild/bazelisk/core",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//httputil",
+        "//platforms",
+    ],
+)

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -1,0 +1,156 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bazelbuild/bazelisk/httputil"
+	"github.com/bazelbuild/bazelisk/platforms"
+)
+
+const (
+	BaseURLEnv    = "BAZELISK_BASE_URL"
+	BazelUpstream = "bazelbuild"
+)
+
+type ReleaseRepo interface {
+	GetReleaseVersions(bazeliskHome string) ([]string, error)
+	DownloadRelease(version, destDir, destFile string) (string, error)
+}
+
+type CandidateRepo interface {
+	GetCandidateVersions(bazeliskHome string) ([]string, error)
+	DownloadCandidate(version, destDir, destFile string) (string, error)
+}
+
+type ForkRepo interface {
+	GetVersions(bazeliskHome, fork string) ([]string, error)
+	DownloadVersion(fork, version, destDir, destFile string) (string, error)
+}
+
+type LastGreenRepo interface {
+	GetLastGreenVersion(bazeliskHome string, downstreamGreen bool) (string, error)
+	DownloadLastGreen(commit, destDir, destFile string) (string, error)
+}
+
+type Repositories struct {
+	Releases        ReleaseRepo
+	Candidates      CandidateRepo
+	Fork            ForkRepo
+	LastGreen       LastGreenRepo
+	supportsBaseURL bool
+}
+
+func IsFork(value string) bool {
+	return value != "" && value != BazelUpstream
+}
+
+func (r *Repositories) DownloadFromRepo(fork, version string, isCommit bool, destDir, destFile string) (string, error) {
+	switch {
+	case IsFork(fork):
+		return r.Fork.DownloadVersion(fork, version, destDir, destFile)
+	case isCommit:
+		return r.LastGreen.DownloadLastGreen(version, destDir, destFile)
+	case strings.Contains(version, "rc"):
+		return r.Candidates.DownloadCandidate(version, destDir, destFile)
+	default:
+		return r.Releases.DownloadRelease(version, destDir, destFile)
+	}
+}
+
+func (r *Repositories) DownloadFromBaseURL(baseURL, version, destDir, destFile string) (string, error) {
+	if !r.supportsBaseURL {
+		return "", fmt.Errorf("downloads from %s are forbidden", BaseURLEnv)
+	} else if baseURL == "" {
+		return "", fmt.Errorf("%s is not set", BaseURLEnv)
+	}
+
+	srcFile, err := platforms.DetermineBazelFilename(version, true)
+	if err != nil {
+		return "", err
+	}
+
+	url := fmt.Sprintf("%s/%s/%s", baseURL, version, srcFile)
+	return httputil.DownloadBinary(url, destDir, destFile)
+}
+
+func CreateRepositories(releases ReleaseRepo, candidates CandidateRepo, fork ForkRepo, lastGreen LastGreenRepo, supportsBaseURL bool) *Repositories {
+	repos := &Repositories{supportsBaseURL: supportsBaseURL}
+
+	if releases == nil {
+		repos.Releases = &noReleaseRepo{errors.New("official Bazel releases are not supported")}
+	} else {
+		repos.Releases = releases
+	}
+
+	if candidates == nil {
+		repos.Candidates = &noCandidateRepo{errors.New("Bazel release candidates are not supported")}
+	} else {
+		repos.Candidates = candidates
+	}
+
+	if fork == nil {
+		repos.Fork = &noForkRepo{errors.New("forked versions of Bazel are not supported")}
+	} else {
+		repos.Fork = fork
+	}
+
+	if lastGreen == nil {
+		repos.LastGreen = &noLastGreenRepo{errors.New("Bazel-at-last-green versions are not supported")}
+	} else {
+		repos.LastGreen = lastGreen
+	}
+
+	return repos
+}
+
+// The whole point of the structs below this line is that users can simply call repos.Releases.GetReleaseVersions()
+// (etc) without having to worry whether `Releases` points at an actual repo.
+type noReleaseRepo struct {
+	Error error
+}
+
+func (nrr *noReleaseRepo) GetReleaseVersions(bazeliskHome string) ([]string, error) {
+	return []string{}, nrr.Error
+}
+
+func (nrr *noReleaseRepo) DownloadRelease(version, destDir, destFile string) (string, error) {
+	return "", nrr.Error
+}
+
+type noCandidateRepo struct {
+	Error error
+}
+
+func (ncc *noCandidateRepo) GetCandidateVersions(bazeliskHome string) ([]string, error) {
+	return []string{}, ncc.Error
+}
+
+func (ncc *noCandidateRepo) DownloadCandidate(version, destDir, destFile string) (string, error) {
+	return "", ncc.Error
+}
+
+type noForkRepo struct {
+	Error error
+}
+
+func (nfr *noForkRepo) GetVersions(bazeliskHome, fork string) ([]string, error) {
+	return []string{}, nfr.Error
+}
+
+func (nfr *noForkRepo) DownloadVersion(fork, version, destDir, destFile string) (string, error) {
+	return "", nfr.Error
+}
+
+type noLastGreenRepo struct {
+	Error error
+}
+
+func (nlgr *noLastGreenRepo) GetLastGreenVersion(bazeliskHome string, downstreamGreen bool) (string, error) {
+	return "", nlgr.Error
+}
+
+func (nlgr *noLastGreenRepo) DownloadLastGreen(commit, destDir, destFile string) (string, error) {
+	return "", nlgr.Error
+}

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -52,7 +52,7 @@ type CommitRepo interface {
 	// it's https://buildkite.com/bazel/bazel-bazel
 	GetLastGreenCommit(bazeliskHome string, downstreamGreen bool) (string, error)
 
-	//DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
+	// DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
 	DownloadAtCommit(commit, destDir, destFile string) (string, error)
 }
 

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -62,7 +62,7 @@ func (r *Repositories) ResolveVersion(bazeliskHome, fork, version string) (strin
 	return "", nil, fmt.Errorf("Unsupported version identifier '%s'", version)
 }
 
-func (r *Repositories) resolveFork(bazeliskHome string, vi *versions.VersionInfo) (string, DownloadFunc, error) {
+func (r *Repositories) resolveFork(bazeliskHome string, vi *versions.Info) (string, DownloadFunc, error) {
 	if vi.IsRelative && (vi.IsCandidate || vi.IsCommit) {
 		return "", nil, errors.New("forks do not support last_rc, last_green and last_downstream_green")
 	}
@@ -79,7 +79,7 @@ func (r *Repositories) resolveFork(bazeliskHome string, vi *versions.VersionInfo
 	return version, downloader, nil
 }
 
-func (r *Repositories) resolveRelease(bazeliskHome string, vi *versions.VersionInfo) (string, DownloadFunc, error) {
+func (r *Repositories) resolveRelease(bazeliskHome string, vi *versions.Info) (string, DownloadFunc, error) {
 	version, err := resolvePotentiallyRelativeVersion(bazeliskHome, r.Releases.GetReleaseVersions, vi)
 	if err != nil {
 		return "", nil, err
@@ -90,7 +90,7 @@ func (r *Repositories) resolveRelease(bazeliskHome string, vi *versions.VersionI
 	return version, downloader, nil
 }
 
-func (r *Repositories) resolveCandidate(bazeliskHome string, vi *versions.VersionInfo) (string, DownloadFunc, error) {
+func (r *Repositories) resolveCandidate(bazeliskHome string, vi *versions.Info) (string, DownloadFunc, error) {
 	version, err := resolvePotentiallyRelativeVersion(bazeliskHome, r.Candidates.GetCandidateVersions, vi)
 	if err != nil {
 		return "", nil, err
@@ -101,7 +101,7 @@ func (r *Repositories) resolveCandidate(bazeliskHome string, vi *versions.Versio
 	return version, downloader, nil
 }
 
-func (r *Repositories) resolveCommit(bazeliskHome string, vi *versions.VersionInfo) (string, DownloadFunc, error) {
+func (r *Repositories) resolveCommit(bazeliskHome string, vi *versions.Info) (string, DownloadFunc, error) {
 	version := vi.Value
 	if vi.IsRelative {
 		var err error
@@ -118,7 +118,7 @@ func (r *Repositories) resolveCommit(bazeliskHome string, vi *versions.VersionIn
 
 type listVersionsFunc func(bazeliskHome string) ([]string, error)
 
-func resolvePotentiallyRelativeVersion(bazeliskHome string, lister listVersionsFunc, vi *versions.VersionInfo) (string, error) {
+func resolvePotentiallyRelativeVersion(bazeliskHome string, lister listVersionsFunc, vi *versions.Info) (string, error) {
 	if !vi.IsRelative {
 		return vi.Value, nil
 	}

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "httputil",
+    srcs = ["httputil.go"],
+    importpath = "github.com/bazelbuild/bazelisk/httputil",
+    visibility = ["//visibility:public"],
+)

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,0 +1,128 @@
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var (
+	DefaultTransport = http.DefaultTransport
+)
+
+func getClient() *http.Client {
+	return &http.Client{Transport: DefaultTransport}
+}
+
+func ReadRemoteFile(url string, token string) ([]byte, error) {
+	client := getClient()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create request: %v", err)
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch %s: %v", url, err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status code while reading %s: %v", url, res.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read content at %s: %v", url, err)
+	}
+	return body, nil
+}
+
+func DownloadBinary(originURL, destDir, destFile string) (string, error) {
+	err := os.MkdirAll(destDir, 0755)
+	if err != nil {
+		return "", fmt.Errorf("could not create directory %s: %v", destDir, err)
+	}
+	destinationPath := filepath.Join(destDir, destFile)
+
+	if _, err := os.Stat(destinationPath); err != nil {
+		tmpfile, err := ioutil.TempFile(destDir, "download")
+		if err != nil {
+			return "", fmt.Errorf("could not create temporary file: %v", err)
+		}
+		defer func() {
+			err := tmpfile.Close()
+			if err == nil {
+				os.Remove(tmpfile.Name())
+			}
+		}()
+
+		log.Printf("Downloading %s...", originURL)
+		resp, err := getClient().Get(originURL)
+		if err != nil {
+			return "", fmt.Errorf("HTTP GET %s failed: %v", originURL, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			return "", fmt.Errorf("HTTP GET %s failed with error %v", originURL, resp.StatusCode)
+		}
+
+		_, err = io.Copy(tmpfile, resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("could not copy from %s to %s: %v", originURL, tmpfile.Name(), err)
+		}
+
+		err = os.Chmod(tmpfile.Name(), 0755)
+		if err != nil {
+			return "", fmt.Errorf("could not chmod file %s: %v", tmpfile.Name(), err)
+		}
+
+		tmpfile.Close()
+		err = os.Rename(tmpfile.Name(), destinationPath)
+		if err != nil {
+			return "", fmt.Errorf("could not move %s to %s: %v", tmpfile.Name(), destinationPath, err)
+		}
+	}
+
+	return destinationPath, nil
+}
+
+// MaybeDownload will download a file from the given url and cache the result under bazeliskHome.
+// It skips the download if the file already exists and is not outdated.
+// description is used only to provide better error messages.
+func MaybeDownload(bazeliskHome, url, filename, description, token string) ([]byte, error) {
+	cachePath := filepath.Join(bazeliskHome, filename)
+
+	if cacheStat, err := os.Stat(cachePath); err == nil {
+		if time.Since(cacheStat.ModTime()).Hours() < 1 {
+			res, err := ioutil.ReadFile(cachePath)
+			if err != nil {
+				return nil, fmt.Errorf("could not read %s: %v", cachePath, err)
+			}
+			return res, nil
+		}
+	}
+
+	// We could also use go-github here, but I can't get it to build with Bazel's rules_go and it pulls in a lot of dependencies.
+	body, err := ReadRemoteFile(url, token)
+	if err != nil {
+		return nil, fmt.Errorf("could not download %s: %v", description, err)
+	}
+
+	err = ioutil.WriteFile(cachePath, body, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %s: %v", cachePath, err)
+	}
+
+	return body, nil
+}

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,3 +1,4 @@
+// Package httputil offers functions to read and download files via HTTP.
 package httputil
 
 import (
@@ -12,6 +13,7 @@ import (
 )
 
 var (
+	// DefaultTransport specifies the http.RoundTripper that is used for any network traffic, and may be replaced with a dummy implementation for unit testing.
 	DefaultTransport = http.DefaultTransport
 )
 
@@ -19,6 +21,7 @@ func getClient() *http.Client {
 	return &http.Client{Transport: DefaultTransport}
 }
 
+// ReadRemoteFile returns the contents of the given file, using the supplied Authorization token, if set.
 func ReadRemoteFile(url string, token string) ([]byte, error) {
 	client := getClient()
 	req, err := http.NewRequest("GET", url, nil)
@@ -47,6 +50,7 @@ func ReadRemoteFile(url string, token string) ([]byte, error) {
 	return body, nil
 }
 
+// DownloadBinary downloads a file from the given URL into the specified location, marks it executable and returns its full path.
 func DownloadBinary(originURL, destDir, destFile string) (string, error) {
 	err := os.MkdirAll(destDir, 0755)
 	if err != nil {
@@ -97,9 +101,9 @@ func DownloadBinary(originURL, destDir, destFile string) (string, error) {
 	return destinationPath, nil
 }
 
-// MaybeDownload will download a file from the given url and cache the result under bazeliskHome.
+// MaybeDownload downloads a file from the given url and caches the result under bazeliskHome.
 // It skips the download if the file already exists and is not outdated.
-// description is used only to provide better error messages.
+// Parameter ´description´ is only used to provide better error messages.
 func MaybeDownload(bazeliskHome, url, filename, description, token string) ([]byte, error) {
 	cachePath := filepath.Join(bazeliskHome, filename)
 

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "platforms",
+    srcs = ["platforms.go"],
+    importpath = "github.com/bazelbuild/bazelisk/platforms",
+    visibility = ["//visibility:public"],
+)

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -1,3 +1,4 @@
+// Package platforms determins file names and extensions based on the current operating system.
 package platforms
 
 import (
@@ -7,10 +8,13 @@ import (
 
 var platforms = map[string]string{"darwin": "macos", "linux": "ubuntu1404", "windows": "windows"}
 
+// GetPlatform returns a Bazel CI-compatible platform identifier for the current operating system.
+// TODO(fweikert): raise an error for unsupported platforms
 func GetPlatform() string {
 	return platforms[runtime.GOOS]
 }
 
+// DetermineExecutableFilenameSuffix returns the extension for binaries on the current operating system.
 func DetermineExecutableFilenameSuffix() string {
 	filenameSuffix := ""
 	if runtime.GOOS == "windows" {
@@ -19,6 +23,7 @@ func DetermineExecutableFilenameSuffix() string {
 	return filenameSuffix
 }
 
+// DetermineBazelFilename returns the correct file name of a local Bazel binary.
 func DetermineBazelFilename(version string, includeSuffix bool) (string, error) {
 	var machineName string
 	switch runtime.GOARCH {

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -1,0 +1,47 @@
+package platforms
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var platforms = map[string]string{"darwin": "macos", "linux": "ubuntu1404", "windows": "windows"}
+
+func GetPlatform() string {
+	return platforms[runtime.GOOS]
+}
+
+func DetermineExecutableFilenameSuffix() string {
+	filenameSuffix := ""
+	if runtime.GOOS == "windows" {
+		filenameSuffix = ".exe"
+	}
+	return filenameSuffix
+}
+
+func DetermineBazelFilename(version string, includeSuffix bool) (string, error) {
+	var machineName string
+	switch runtime.GOARCH {
+	case "amd64":
+		machineName = "x86_64"
+	case "arm64":
+		machineName = "arm64"
+	default:
+		return "", fmt.Errorf("unsupported machine architecture \"%s\", must be arm64 or x86_64", runtime.GOARCH)
+	}
+
+	var osName string
+	switch runtime.GOOS {
+	case "darwin", "linux", "windows":
+		osName = runtime.GOOS
+	default:
+		return "", fmt.Errorf("unsupported operating system \"%s\", must be Linux, macOS or Windows", runtime.GOOS)
+	}
+
+	var filenameSuffix string
+	if includeSuffix {
+		filenameSuffix = DetermineExecutableFilenameSuffix()
+	}
+
+	return fmt.Sprintf("bazel-%s-%s-%s%s", version, osName, machineName, filenameSuffix), nil
+}

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "repositories",
+    srcs = [
+        "gcs.go",
+        "github.go",
+    ],
+    importpath = "github.com/bazelbuild/bazelisk/repositories",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//httputil",
+        "//platforms",
+        "//versions",
+    ],
+)

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -1,0 +1,154 @@
+package repositories
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bazelbuild/bazelisk/httputil"
+	"github.com/bazelbuild/bazelisk/platforms"
+	"github.com/bazelbuild/bazelisk/versions"
+)
+
+const (
+	candidateBaseURL    = "https://releases.bazel.build"
+	nonCandidateBaseURL = "https://storage.googleapis.com/bazel-builds/artifacts"
+	lastGreenBaseURL    = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/"
+)
+
+var (
+	// key == includeDownstream
+	lastGreenCommitPathSuffixes = map[bool]string{
+		false: "github.com/bazelbuild/bazel.git/bazel-bazel",
+		true:  "downstream_pipeline",
+	}
+)
+
+type GCSRepo struct{}
+
+// ReleaseRepo
+func (gcs *GCSRepo) GetReleaseVersions(bazeliskHome string) ([]string, error) {
+	return getVersionHistoryFromGCS(true)
+}
+
+func getVersionHistoryFromGCS(onlyFullReleases bool) ([]string, error) {
+	prefixes, _, err := listDirectoriesInReleaseBucket("")
+	if err != nil {
+		return []string{}, fmt.Errorf("could not list Bazel versions in GCS bucket: %v", err)
+	}
+
+	available := getVersionsFromGCSPrefixes(prefixes)
+	sorted := versions.GetInAscendingOrder(available)
+
+	if onlyFullReleases && len(sorted) > 0 {
+		latestVersion := sorted[len(sorted)-1]
+		_, isRelease, err := listDirectoriesInReleaseBucket(latestVersion + "/release/")
+		if err != nil {
+			return []string{}, fmt.Errorf("could not list release candidates for latest release: %v", err)
+		}
+		if !isRelease {
+			sorted = sorted[:len(sorted)-1]
+		}
+	}
+
+	return sorted, nil
+}
+
+func listDirectoriesInReleaseBucket(prefix string) ([]string, bool, error) {
+	url := "https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/"
+	if prefix != "" {
+		url = fmt.Sprintf("%s&prefix=%s", url, prefix)
+	}
+	content, err := httputil.ReadRemoteFile(url, "")
+	if err != nil {
+		return nil, false, fmt.Errorf("could not list GCS objects at %s: %v", url, err)
+	}
+
+	var response GcsListResponse
+	if err := json.Unmarshal(content, &response); err != nil {
+		return nil, false, fmt.Errorf("could not parse GCS index JSON: %v", err)
+	}
+	return response.Prefixes, len(response.Items) > 0, nil
+}
+
+func getVersionsFromGCSPrefixes(versions []string) []string {
+	result := make([]string, len(versions))
+	for i, v := range versions {
+		result[i] = strings.ReplaceAll(v, "/", "")
+	}
+	return result
+}
+
+// Public for testing
+type GcsListResponse struct {
+	Prefixes []string      `json:"prefixes"`
+	Items    []interface{} `json:"items"`
+}
+
+func (gcs *GCSRepo) DownloadRelease(version, destDir, destFile string) (string, error) {
+	srcFile, err := platforms.DetermineBazelFilename(version, true)
+	if err != nil {
+		return "", err
+	}
+
+	url := fmt.Sprintf("%s/%s/release/%s", candidateBaseURL, version, srcFile)
+	return httputil.DownloadBinary(url, destDir, destFile)
+}
+
+// CandidateRepo
+func (gcs *GCSRepo) GetCandidateVersions(bazeliskHome string) ([]string, error) {
+	available, err := getVersionHistoryFromGCS(false)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(available) == 0 {
+		return []string{}, errors.New("could not find any Bazel versions")
+	}
+
+	sorted := versions.GetInAscendingOrder(available)
+	latestVersion := sorted[len(sorted)-1]
+
+	// Append slash to match directories
+	rcPrefixes, _, err := listDirectoriesInReleaseBucket(latestVersion + "/")
+	if err != nil {
+		return []string{}, fmt.Errorf("could not list release candidates for latest release: %v", err)
+	}
+
+	return getVersionsFromGCSPrefixes(rcPrefixes), nil
+}
+
+func (gcs *GCSRepo) DownloadCandidate(version, destDir, destFile string) (string, error) {
+	if !strings.Contains(version, "rc") {
+		return "", fmt.Errorf("'%s' does not refer to a release candidate", version)
+	}
+
+	srcFile, err := platforms.DetermineBazelFilename(version, true)
+	if err != nil {
+		return "", err
+	}
+
+	versionComponents := strings.Split(version, "rc")
+	baseVersion := versionComponents[0]
+	rcVersion := "rc" + versionComponents[1]
+	url := fmt.Sprintf("%s/%s/%s/%s", candidateBaseURL, baseVersion, rcVersion, srcFile)
+	return httputil.DownloadBinary(url, destDir, destFile)
+}
+
+// LastGreenRepo
+func (gcs *GCSRepo) GetLastGreenVersion(bazeliskHome string, downstreamGreen bool) (string, error) {
+	pathSuffix := lastGreenCommitPathSuffixes[downstreamGreen]
+	content, err := httputil.ReadRemoteFile(lastGreenBaseURL+pathSuffix, "")
+	if err != nil {
+		return "", fmt.Errorf("could not determine last green commit: %v", err)
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+func (gcs *GCSRepo) DownloadLastGreen(commit, destDir, destFile string) (string, error) {
+	log.Printf("Using unreleased version at commit %s", commit)
+	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platforms.GetPlatform(), commit)
+	return httputil.DownloadBinary(url, destDir, destFile)
+}

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -166,7 +166,7 @@ func (gcs *GCSRepo) GetLastGreenCommit(bazeliskHome string, downstreamGreen bool
 	return strings.TrimSpace(string(content)), nil
 }
 
-//DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
+// DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
 func (gcs *GCSRepo) DownloadAtCommit(commit, destDir, destFile string) (string, error) {
 	log.Printf("Using unreleased version at commit %s", commit)
 	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platforms.GetPlatform(), commit)

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -137,8 +137,8 @@ func (gcs *GCSRepo) DownloadCandidate(version, destDir, destFile string) (string
 	return httputil.DownloadBinary(url, destDir, destFile)
 }
 
-// LastGreenRepo
-func (gcs *GCSRepo) GetLastGreenVersion(bazeliskHome string, downstreamGreen bool) (string, error) {
+// CommitRepo
+func (gcs *GCSRepo) GetLastGreenCommit(bazeliskHome string, downstreamGreen bool) (string, error) {
 	pathSuffix := lastGreenCommitPathSuffixes[downstreamGreen]
 	content, err := httputil.ReadRemoteFile(lastGreenBaseURL+pathSuffix, "")
 	if err != nil {
@@ -147,7 +147,7 @@ func (gcs *GCSRepo) GetLastGreenVersion(bazeliskHome string, downstreamGreen boo
 	return strings.TrimSpace(string(content)), nil
 }
 
-func (gcs *GCSRepo) DownloadLastGreen(commit, destDir, destFile string) (string, error) {
+func (gcs *GCSRepo) DownloadAtCommit(commit, destDir, destFile string) (string, error) {
 	log.Printf("Using unreleased version at commit %s", commit)
 	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platforms.GetPlatform(), commit)
 	return httputil.DownloadBinary(url, destDir, destFile)

--- a/repositories/github.go
+++ b/repositories/github.go
@@ -12,15 +12,19 @@ const (
 	urlPattern = "https://github.com/%s/bazel/releases/download/%s/%s"
 )
 
+// GitHubRepo represents a fork of Bazel hosted on GitHub, and provides a list of all available Bazel binaries in that repo, as well as the ability to download them.
 type GitHubRepo struct {
 	token string
 }
 
+// CreateGitHubRepo instantiates a new GitHubRepo.
 func CreateGitHubRepo(token string) *GitHubRepo {
 	return &GitHubRepo{token}
 }
 
 // ForkRepo
+
+// GetVersions returns the versions of all available Bazel binaries in the given fork.
 func (gh *GitHubRepo) GetVersions(bazeliskHome, bazelFork string) ([]string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/bazel/releases", bazelFork)
 	releasesJSON, err := httputil.MaybeDownload(bazeliskHome, url, bazelFork+"-releases.json", "list of Bazel releases from github.com/"+bazelFork, gh.token)
@@ -48,6 +52,7 @@ type gitHubRelease struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
+// DownloadVersion downloads a Bazel binary for the given version and fork to the specified location and returns the absolute path.
 func (gh *GitHubRepo) DownloadVersion(fork, version, destDir, destFile string) (string, error) {
 	filename, err := platforms.DetermineBazelFilename(version, true)
 	if err != nil {

--- a/repositories/github.go
+++ b/repositories/github.go
@@ -1,0 +1,58 @@
+package repositories
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/bazelbuild/bazelisk/httputil"
+	"github.com/bazelbuild/bazelisk/platforms"
+)
+
+const (
+	urlPattern = "https://github.com/%s/bazel/releases/download/%s/%s"
+)
+
+type GitHubRepo struct {
+	token string
+}
+
+func CreateGitHubRepo(token string) *GitHubRepo {
+	return &GitHubRepo{token}
+}
+
+// ForkRepo
+func (gh *GitHubRepo) GetVersions(bazeliskHome, bazelFork string) ([]string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/bazel/releases", bazelFork)
+	releasesJSON, err := httputil.MaybeDownload(bazeliskHome, url, bazelFork+"-releases.json", "list of Bazel releases from github.com/"+bazelFork, gh.token)
+	if err != nil {
+		return []string{}, fmt.Errorf("unable to dermine '%s' releases: %v", bazelFork, err)
+	}
+
+	var releases []gitHubRelease
+	if err := json.Unmarshal(releasesJSON, &releases); err != nil {
+		return []string{}, fmt.Errorf("could not parse JSON into list of releases: %v", err)
+	}
+
+	var tags []string
+	for _, release := range releases {
+		if release.Prerelease {
+			continue
+		}
+		tags = append(tags, release.TagName)
+	}
+	return tags, nil
+}
+
+type gitHubRelease struct {
+	TagName    string `json:"tag_name"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+func (gh *GitHubRepo) DownloadVersion(fork, version, destDir, destFile string) (string, error) {
+	filename, err := platforms.DetermineBazelFilename(version, true)
+	if err != nil {
+		return "", err
+	}
+	url := fmt.Sprintf(urlPattern, fork, version, filename)
+	return httputil.DownloadBinary(url, destDir, destFile)
+}

--- a/versions/BUILD
+++ b/versions/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "versions",
+    srcs = [
+        "versions.go",
+    ],
+    importpath = "github.com/bazelbuild/bazelisk/versions",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_hashicorp_go_version//:go_default_library",
+    ],
+)

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -1,0 +1,26 @@
+package versions
+
+import (
+	"log"
+	"sort"
+
+	"github.com/hashicorp/go-version"
+)
+
+func GetInAscendingOrder(versions []string) []string {
+	wrappers := make([]*version.Version, len(versions))
+	for i, v := range versions {
+		wrapper, err := version.NewVersion(v)
+		if err != nil {
+			log.Printf("WARN: Could not parse version: %s", v)
+		}
+		wrappers[i] = wrapper
+	}
+	sort.Sort(version.Collection(wrappers))
+
+	sorted := make([]string, len(versions))
+	for i, w := range wrappers {
+		sorted[i] = w.Original()
+	}
+	return sorted
+}

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -1,3 +1,4 @@
+// Package versions contains functions to parse and sort Bazel version identifier.
 package versions
 
 import (
@@ -11,6 +12,7 @@ import (
 )
 
 const (
+	// BazelUpstream contains the name of the official Bazel GitHub organization.
 	BazelUpstream = "bazelbuild"
 )
 
@@ -21,14 +23,16 @@ var (
 	commitPattern        = regexp.MustCompile(`^[a-z0-9]{40}$`)
 )
 
+// Info represents a structured Bazel version identifier.
 type Info struct {
 	IsRelease, IsCandidate, IsCommit, IsFork, IsRelative, IsDownstream bool
 	Fork, Value                                                        string
 	LatestOffset                                                       int
 }
 
+// Parse extracts and returns structured information about the given Bazel version label.
 func Parse(fork, version string) (*Info, error) {
-	vi := &Info{Fork: fork, Value: version, IsFork: IsFork(fork)}
+	vi := &Info{Fork: fork, Value: version, IsFork: isFork(fork)}
 
 	if releasePattern.MatchString(version) {
 		vi.IsRelease = true
@@ -62,10 +66,11 @@ func Parse(fork, version string) (*Info, error) {
 	return vi, nil
 }
 
-func IsFork(value string) bool {
+func isFork(value string) bool {
 	return value != "" && value != BazelUpstream
 }
 
+// GetInAscendingOrder returns the given versions sorted in ascending order.
 func GetInAscendingOrder(versions []string) []string {
 	wrappers := make([]*version.Version, len(versions))
 	for i, v := range versions {

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -21,14 +21,14 @@ var (
 	commitPattern        = regexp.MustCompile(`^[a-z0-9]{40}$`)
 )
 
-type VersionInfo struct {
+type Info struct {
 	IsRelease, IsCandidate, IsCommit, IsFork, IsRelative, IsDownstream bool
 	Fork, Value                                                        string
 	LatestOffset                                                       int
 }
 
-func Parse(fork, version string) (*VersionInfo, error) {
-	vi := &VersionInfo{Fork: fork, Value: version, IsFork: IsFork(fork)}
+func Parse(fork, version string) (*Info, error) {
+	vi := &Info{Fork: fork, Value: version, IsFork: IsFork(fork)}
 
 	if releasePattern.MatchString(version) {
 		vi.IsRelease = true

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -1,11 +1,70 @@
 package versions
 
 import (
+	"fmt"
 	"log"
+	"regexp"
 	"sort"
+	"strconv"
 
 	"github.com/hashicorp/go-version"
 )
+
+const (
+	BazelUpstream = "bazelbuild"
+)
+
+var (
+	releasePattern       = regexp.MustCompile(`^(\d+.\d+.\d+)$`)
+	candidatePattern     = regexp.MustCompile(`^(\d+.\d+.\d+)rc(\d+)$`)
+	latestReleasePattern = regexp.MustCompile(`^latest(?:-(?P<offset>\d+))?$`)
+	commitPattern        = regexp.MustCompile(`^[a-z0-9]{40}$`)
+)
+
+type VersionInfo struct {
+	IsRelease, IsCandidate, IsCommit, IsFork, IsRelative, IsDownstream bool
+	Fork, Value                                                        string
+	LatestOffset                                                       int
+}
+
+func Parse(fork, version string) (*VersionInfo, error) {
+	vi := &VersionInfo{Fork: fork, Value: version, IsFork: IsFork(fork)}
+
+	if releasePattern.MatchString(version) {
+		vi.IsRelease = true
+	} else if m := latestReleasePattern.FindStringSubmatch(version); m != nil {
+		vi.IsRelease = true
+		vi.IsRelative = true
+		if m[1] != "" {
+			offset, err := strconv.Atoi(m[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid version \"%s\", could not parse offset: %v", version, err)
+			}
+			vi.LatestOffset = offset
+		}
+	} else if candidatePattern.MatchString(version) {
+		vi.IsCandidate = true
+	} else if version == "last_rc" {
+		vi.IsCandidate = true
+		vi.IsRelative = true
+	} else if commitPattern.MatchString(version) {
+		vi.IsCommit = true
+	} else if version == "last_green" {
+		vi.IsCommit = true
+		vi.IsRelative = true
+	} else if version == "last_downstream_green" {
+		vi.IsCommit = true
+		vi.IsRelative = true
+		vi.IsDownstream = true
+	} else {
+		return nil, fmt.Errorf("Invalid version '%s'", version)
+	}
+	return vi, nil
+}
+
+func IsFork(value string) bool {
+	return value != "" && value != BazelUpstream
+}
 
 func GetInAscendingOrder(versions []string) []string {
 	wrappers := make([]*version.Version, len(versions))


### PR DESCRIPTION
# Summary

This change introduces dedicated interfaces to handle how Bazel versions are retrieved and downloaded.

# Details

The new `core` package introduces interfaces that represent four kinds of repositories that store Bazel versions: `ReleaseRepo`, `CandidateRepo`, `ForkRepo` and `CommitRepo`. Implementations of these interfaces must provide a list of available Bazel versions, as well as a function to download a desired version (`CommitRepo` is the exception since it must only return two commit hashes, last_green and last_downstream_green).

Implementations of these interfaces must be passed to the new `core.Repositories` struct, which uses them to resolve given Bazel versions and to return an appropriate download function. As a result, the download logic in bazelisk.go was reduced substantially.

The old main function was moved into `RunBazelisk()`, which expects implementations of these interfaces. As a result, the caller of this function can control which repositories are used.

The previously existing repositories, GitHub and GCS, are still supported since they implement the new interfaces. GitHub is used for forks, whereas GCS is used for everything else.

Moreover, the existing `BAZELISK_BASE_URL` environment variable is still supported, and overrides the repository interfaces (if set).

Finally, this change moves some utility functions into new, dedicated packages such as `httputil` (for retrieving files via HTTP), `platforms` (for determining platform specific information) and `versions` (for parsing and sorting version values). 

# Motivation

The idea is to turn Bazelisk into a library that supports arbitrary repositories. For example, companies might want to ship their own version of Bazelisk that fetches all Bazel binaries from their internal servers.

# Next steps

The next PR will move `RunBazelisk()` into the `core` package so that it can be used as a pure library. I didn’t want to move it in this PR to get better code diffs.
Moreover, we should probably split the shell test (see below).

# Functional changes

Even though this is a refactoring, some functional changes have been made:
1. The previous version used GitHub as a fallback when GCS was unavailable. This is no longer the case.
2. Forks no longer support last_rc, last_green and last_downstream_green. Forks historically used GitHub, which never contained these binaries anyway. The new behavior actually matches the documentation.
3. Commit hashes are now valid Bazel version values, which means Bazelisk will attempt to download a Bazel binary built at the given commit.

As a result, the Python version now deviates from the Go version since the latter uses GCS, whereas the first uses GitHub.

This forced me to rewrite the shell test, too, since the Go tests must be less strict wrt expected versions:

Since the Go version uses GCS the fake json file written in the test is only used by the Python version.
As a result, the shell test is effectively an integration test for the Go version and requires network access. Moreover, we can no longer check for specific Bazel version in the Go test since "latest" will point at different releases over time.

We should split the test into proper Go and Python versions.