### PR TITLE
Fix test failure when building in debug mode

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -60,6 +60,12 @@ function bazelisk() {
       echo "Running Bazelisk with $(python -V)..."
       python "$(rlocation __main__/bazelisk.py)" "$@"
     fi
+  elif [[ -n $(rlocation __main__/windows_amd64_debug/bazelisk.exe) ]]; then
+    "$(rlocation __main__/windows_amd64_debug/bazelisk.exe)" "$@"
+  elif [[ -n $(rlocation __main__/darwin_amd64_debug/bazelisk) ]]; then
+    "$(rlocation __main__/darwin_amd64_debug/bazelisk)" "$@"
+  elif [[ -n $(rlocation __main__/linux_amd64_debug/bazelisk) ]]; then
+    "$(rlocation __main__/linux_amd64_debug/bazelisk)" "$@"
   elif [[ -n $(rlocation __main__/windows_amd64_stripped/bazelisk.exe) ]]; then
     "$(rlocation __main__/windows_amd64_stripped/bazelisk.exe)" "$@"
   elif [[ -n $(rlocation __main__/darwin_amd64_stripped/bazelisk) ]]; then


### PR DESCRIPTION
Fixes the "Could not find the bazelisk executable" error that occurred in some test runs.