### PR TITLE
GO: Return latest version from GCS that is a full release

### DIFF
--- a/.bazelci/config.yml
+++ b/.bazelci/config.yml
@@ -3,6 +3,8 @@ platforms:
   ubuntu1604:
     test_targets:
       - //:go_bazelisk_test
+      - //:go_default_test
+      - //:go_version_test
       - //:py_bazelisk_test
       - //:py3_bazelisk_test
     test_flags:
@@ -11,6 +13,8 @@ platforms:
   ubuntu1804:
     test_targets:
       - //:go_bazelisk_test
+      - //:go_default_test
+      - //:go_version_test
       - //:py_bazelisk_test
       - //:py3_bazelisk_test
     test_flags:
@@ -19,6 +23,8 @@ platforms:
   macos:
     test_targets:
       - //:go_bazelisk_test
+      - //:go_default_test
+      - //:go_version_test
       - //:py_bazelisk_test
       - //:py3_bazelisk_test
     test_flags:
@@ -27,6 +33,8 @@ platforms:
   windows:
     test_targets:
       - //:go_bazelisk_test
+      - //:go_default_test
+      - //:go_version_test
       - //:py_bazelisk_test
     test_flags:
       - --flaky_test_attempts=1

--- a/BUILD
+++ b/BUILD
@@ -70,6 +70,10 @@ go_test(
     embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/bazelisk",
     deps = [
+        "//core",
+        "//httputil",
+        "//repositories",
+        "//versions",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -1,4 +1,3 @@
-// Package core contains interfaces to work with Bazel repositories.
 package core
 
 import (

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -52,11 +52,11 @@ func getVersionHistoryFromGCS(onlyFullReleases bool) ([]string, error) {
 	// TODO(#171): This algorithm is incorrect if version == 'latest-n' and any of the last n versions (except the last one) does not have a release yet.
 	if onlyFullReleases {
 		for len(sorted) > 0 {
-			lastIndex := len(sorted)-1
+			lastIndex := len(sorted) - 1
 			latestVersion := sorted[lastIndex]
 			_, isRelease, err := listDirectoriesInReleaseBucket(latestVersion + "/release/")
 			if err != nil {
-				return []string{}, fmt.Errorf("could not list release candidates for latest release: %v", err)
+				return []string{}, fmt.Errorf("could not list available releases for %v: %v", latestVersion, err)
 			}
 			if isRelease {
 				break


### PR DESCRIPTION
If `latest-n` was requested, Bazelisk previously only examined the most recent version to see whether it had a release (and not just candidates).
If there was no release, Bazelisk simply returned the second-to-last one without checking whether that version had a release, too.

Now Bazelisk checks the latest versions until it finds one with a release.

Fixes #170
Progress towards #171