### PR TITLE
add missing dependencies for go_library to BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -46,7 +46,9 @@ go_library(
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
     deps = [
         "//core",
+        "//httputil",
         "//repositories",
+        "//versions",
     ],
 )
 


### PR DESCRIPTION
Currently running `bazel build //...` (`namely, `bazel 3.5.0-homebrew` version) in the root directory fails with the following error (full output is at the bottom):
```
compilepkg: missing strict dependencies:
	/private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/httputil"
	/private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/versions"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
```

PR fixes this by adding the missing httputil and version dependencies to the `go_library` stanza.

Full output of `bazel build`:
```
$ bazel build --show_result 3 --sandbox_debug //...
INFO: Analyzed 17 targets (67 packages loaded, 8206 targets configured).
INFO: Found 17 targets...
INFO: Deleting stale sandbox base /private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox
ERROR: /Users/dmitris/dev/hack/github.com/bazelbuild/bazelisk/BUILD:67:8: GoCompilePkg go_version_test.internal.a failed (Exit 1) sandbox-exec failed: error executing command
  (cd /private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/execroot/__main__ && \
  exec env - \
    APPLE_SDK_PLATFORM=MacOSX \
    APPLE_SDK_VERSION_OVERRIDE=10.15 \
    CGO_ENABLED=1 \
    DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
    GOARCH=amd64 \
    GOOS=darwin \
    GOPATH='' \
    GOROOT=external/go_sdk \
    GOROOT_FINAL=GOROOT \
    PATH=external/local_config_cc:/bin:/usr/bin \
    SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk \
    TMPDIR=/var/folders/h7/2w9hdmf54bg2vm6j_wkvhszr0000gn/T/ \
    XCODE_VERSION_OVERRIDE=12.0.1.12A7300 \
  /usr/bin/sandbox-exec -f /private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/sandbox.sb /var/tmp/_bazel_dmitris/install/e69ece0375730f7401a18676762f819d/process-wrapper '--timeout=0' '--kill_delay=15' bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix darwin_amd64 -src bazelisk.go -src bazelisk_version_test.go -arc 'github.com/bazelbuild/rules_go/go/tools/bazel=github.com/bazelbuild/rules_go/go/tools/bazel=bazel-out/darwin-fastbuild/bin/external/io_bazel_rules_go/go/tools/bazel/bazel.x' -arc 'github.com/bazelbuild/bazelisk/core=github.com/bazelbuild/bazelisk/core=bazel-out/darwin-fastbuild/bin/core/core.x' -arc 'github.com/bazelbuild/bazelisk/repositories=github.com/bazelbuild/bazelisk/repositories=bazel-out/darwin-fastbuild/bin/repositories/repositories.x' -importpath github.com/bazelbuild/bazelisk -p github.com/bazelbuild/bazelisk -package_list bazel-out/host/bin/external/go_sdk/packages.txt -o bazel-out/darwin-fastbuild/bin/go_version_test.internal.a -x bazel-out/darwin-fastbuild/bin/go_version_test.internal.x -testfilter exclude -gcflags '' -asmflags '')
compilepkg: missing strict dependencies:
	/private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/httputil"
	/private/var/tmp/_bazel_dmitris/3113e370cec62af97a23371f8a272b35/sandbox/darwin-sandbox/5/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/versions"
No dependencies were provided.
Check that imports in Go sources match importpath attributes in deps.
```