### PR TITLE
Fix dependencies for go_version_test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -46,7 +46,9 @@ go_library(
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
     deps = [
         "//core",
+        "//httputil",
         "//repositories",
+        "//versions",
     ],
 )
 


### PR DESCRIPTION

Bazelisk at downstream is failing: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/1673
There seems to be a problem collecting test results, so I ran it locally.
Got message:
```
$ bazel test //:go_version_test 
ERROR: /usr/local/google/home/ilist/src/bazelisk/BUILD:67:8: GoCompilePkg go_version_test.internal.a failed (Exit 1): builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src bazelisk.go -src bazelisk_version_test.go -arc ... (remaining 21 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_amd64 -src bazelisk.go -src bazelisk_version_test.go -arc ... (remaining 21 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: missing strict dependencies:
        .../sandbox/linux-sandbox/13/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/httputil"
        .../sandbox/linux-sandbox/13/execroot/__main__/bazelisk_version_test.go: import of "github.com/bazelbuild/bazelisk/versions"
```

The issue seem to be introduced with commit a81efd710174a2533bb5deb0b93b9f95e455a5d5.