### PR TITLE
Move runfiles logic into separate package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -64,8 +64,8 @@ go_test(
         "//core:go_default_library",
         "//httputil:go_default_library",
         "//repositories:go_default_library",
+        "//runfiles:go_default_library",
         "//versions:go_default_library",
-        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
 )
 

--- a/bazelisk_test.go
+++ b/bazelisk_test.go
@@ -2,20 +2,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"sort"
 	"testing"
 
 	"github.com/bazelbuild/bazelisk/core"
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/bazelbuild/bazelisk/runfiles"
 )
 
 func TestScanIssuesForIncompatibleFlags(t *testing.T) {
-	path, err := bazel.Runfile("sample-issues-migration.json")
-	if err != nil {
-		t.Errorf("Can not load sample github issues")
-	}
-	samplesJSON, err := ioutil.ReadFile(path)
+	samplesJSON, err := runfiles.ReadFile("sample-issues-migration.json")
 	if err != nil {
 		t.Errorf("Can not load sample github issues")
 	}

--- a/runfiles/BUILD
+++ b/runfiles/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "runfiles.go",
+    ],
+    importpath = "github.com/bazelbuild/bazelisk/runfiles",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/runfiles/runfiles.go
+++ b/runfiles/runfiles.go
@@ -1,0 +1,20 @@
+// Package runfiles offers functionality to read data dependencies of tests.
+package runfiles
+
+import (
+	"io/ioutil"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func ReadFile(name string) ([]byte, error) {
+	path, err := bazel.Runfile(name)
+	if err != nil {
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}


### PR DESCRIPTION
This is a pure refactoring, which makes it easier for us to use Bazelisk internally.