### PR TITLE
Discard releases when reading candidates

### DIFF
--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -59,6 +59,24 @@ func TestResolveLatestRcVersion(t *testing.T) {
 	}
 }
 
+func TestResolveLatestRcVersion_WithFullRelease(t *testing.T) {
+	s := setUp(t)
+	s.AddVersion("4.0.0", true, 1, 2, 3)
+	s.Finish()
+
+	gcs := &repositories.GCSRepo{}
+	repos := core.CreateRepositories(nil, gcs, nil, nil, false)
+	version, _, err := repos.ResolveVersion(tmpDir, versions.BazelUpstream, "last_rc")
+
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	expectedRC := "4.0.0rc3"
+	if version != expectedRC {
+		t.Fatalf("Expected version %s, but got %s", expectedRC, version)
+	}
+}
+
 func TestResolveLatestVersion_TwoLatestVersionsDoNotHaveAReleaseYet(t *testing.T) {
 	s := setUp(t)
 	s.AddVersion("4.0.0", true)

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -82,7 +82,8 @@ func listDirectoriesInReleaseBucket(prefix string) ([]string, bool, error) {
 func getVersionsFromGCSPrefixes(versions []string) []string {
 	result := make([]string, len(versions))
 	for i, v := range versions {
-		result[i] = strings.ReplaceAll(v, "/", "")
+		noSlashes := strings.ReplaceAll(v, "/", "")
+		result[i] =  strings.TrimSuffix(noSlashes, "release")
 	}
 	return result
 }
@@ -163,7 +164,14 @@ func (gcs *GCSRepo) GetCandidateVersions(bazeliskHome string) ([]string, error) 
 		return []string{}, fmt.Errorf("could not list release candidates for latest release: %v", err)
 	}
 
-	return getVersionsFromGCSPrefixes(rcPrefixes), nil
+	rcs := make([]string, 0)
+	for _, v := range getVersionsFromGCSPrefixes(rcPrefixes) {
+		// Remove full releases
+		if strings.Contains(v, "rc") {
+			rcs = append(rcs, v)
+		}
+	}
+	return rcs, nil
 }
 
 // DownloadCandidate downloads the given release candidate into the specified location and returns the absolute path.


### PR DESCRIPTION
This commit fixes two related problems: when version equaled "last_rc", Bazelisk-Go did not discard release versions, and it returned the "release" suffix as part of the version label (which was invalid, of course).

Fixes #189