### PR TITLE
Ensure Go 1.11 compatibility...

### DIFF
--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -82,7 +82,7 @@ func listDirectoriesInReleaseBucket(prefix string) ([]string, bool, error) {
 func getVersionsFromGCSPrefixes(versions []string) []string {
 	result := make([]string, len(versions))
 	for i, v := range versions {
-		noSlashes := strings.ReplaceAll(v, "/", "")
+		noSlashes := strings.Replace(v, "/", "", -1)
 		result[i] =  strings.TrimSuffix(noSlashes, "release")
 	}
 	return result


### PR DESCRIPTION
...by replacing strings.ReplaceAll() with strings.Replace().

Progress towards #206