### PR TITLE
Fix workspace root detection by ignoring directories

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -200,12 +200,24 @@ func GetEnvOrConfig(name string) string {
 	return fileConfig[name]
 }
 
+// isValidWorkspace returns true iff the supplied path is the workspace root, defined by the presence of
+// a file named WORKSPACE or WORKSPACE.bazel
+// see https://github.com/bazelbuild/bazel/blob/8346ea4cfdd9fbd170d51a528fee26f912dad2d5/src/main/cpp/workspace_layout.cc#L37
+func isWorkspaceRoot(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	
+	return !info.IsDir()
+}
+
 func findWorkspaceRoot(root string) string {
-	if _, err := os.Stat(filepath.Join(root, "WORKSPACE")); err == nil {
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE")) {
 		return root
 	}
 
-	if _, err := os.Stat(filepath.Join(root, "WORKSPACE.bazel")); err == nil {
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE.bazel")) {
 		return root
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -203,7 +203,7 @@ func GetEnvOrConfig(name string) string {
 // isValidWorkspace returns true iff the supplied path is the workspace root, defined by the presence of
 // a file named WORKSPACE or WORKSPACE.bazel
 // see https://github.com/bazelbuild/bazel/blob/8346ea4cfdd9fbd170d51a528fee26f912dad2d5/src/main/cpp/workspace_layout.cc#L37
-func isWorkspaceRoot(path string) bool {
+func isValidWorkspace(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false


### PR DESCRIPTION
On case-insensitive filesystems, bazelisk can fail to find the workspace root if you have a directory named `workspace/`. This patch updates `findWorkspaceRoot` to ensure that a workspace root is only returned if the WORKSPACE / WORKSPACE.bazel file exists and is not a directory, and makes bazelisk consistent with bazel itself (see comments in the patch for a link)