### PR TITLE
Fix #219: Provide ARM releases (for Mac M1)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -76,7 +76,7 @@ go_binary(
 )
 
 go_binary(
-    name = "bazelisk-darwin",
+    name = "bazelisk-darwin-amd64",
     out = "bazelisk-darwin_amd64",
     embed = [":go_default_library"],
     gc_linkopts = [
@@ -90,7 +90,32 @@ go_binary(
 )
 
 go_binary(
-    name = "bazelisk-linux",
+    name = "bazelisk-darwin-arm64",
+    out = "bazelisk-darwin_arm64",
+    embed = [":go_default_library"],
+    gc_linkopts = [
+        "-s",
+        "-w",
+    ],
+    goarch = "arm64",
+    goos = "darwin",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "bazelisk-darwin-universal",
+    srcs = [
+        ":bazelisk-darwin_amd64",
+        ":bazelisk-darwin_arm64",
+    ],
+    outs = ["bazelisk-darwin_universal"],
+    cmd = "lipo -create -output \"$@\" $(SRCS)",
+    output_to_bindir = 1,
+)
+
+go_binary(
+    name = "bazelisk-linux-amd64",
     out = "bazelisk-linux_amd64",
     embed = [":go_default_library"],
     gc_linkopts = [
@@ -118,7 +143,7 @@ go_binary(
 )
 
 go_binary(
-    name = "bazelisk-windows",
+    name = "bazelisk-windows-amd64",
     out = "bazelisk-windows_amd64.exe",
     embed = [":go_default_library"],
     goarch = "amd64",
@@ -128,18 +153,26 @@ go_binary(
 )
 
 genrule(
-    name = "bazelisk-darwin-for-npm",
-    srcs = [":bazelisk-darwin"],
+    name = "bazelisk-darwin-amd64-for-npm",
+    srcs = [":bazelisk-darwin-amd64"],
     outs = ["bazelisk-darwin_amd64"],
-    cmd = "cp $(location :bazelisk-darwin) \"$@\"",
+    cmd = "cp $(location :bazelisk-darwin-amd64) \"$@\"",
     output_to_bindir = 1,
 )
 
 genrule(
-    name = "bazelisk-linux-for-npm",
-    srcs = [":bazelisk-linux"],
+    name = "bazelisk-darwin-arm64-for-npm",
+    srcs = [":bazelisk-darwin-arm64"],
+    outs = ["bazelisk-darwin_arm64"],
+    cmd = "cp $(location :bazelisk-darwin-arm64) \"$@\"",
+    output_to_bindir = 1,
+)
+
+genrule(
+    name = "bazelisk-linux-amd64-for-npm",
+    srcs = [":bazelisk-linux-amd64"],
     outs = ["bazelisk-linux_amd64"],
-    cmd = "cp $(location :bazelisk-linux) \"$@\"",
+    cmd = "cp $(location :bazelisk-linux-amd64) \"$@\"",
     output_to_bindir = 1,
 )
 
@@ -152,10 +185,10 @@ genrule(
 )
 
 genrule(
-    name = "bazelisk-windows-for-npm",
-    srcs = [":bazelisk-windows"],
+    name = "bazelisk-windows-amd64-for-npm",
+    srcs = [":bazelisk-windows-amd64"],
     outs = ["bazelisk-windows_amd64.exe"],
-    cmd = "cp $(location :bazelisk-windows) \"$@\"",
+    cmd = "cp $(location :bazelisk-windows-amd64) \"$@\"",
     output_to_bindir = 1,
 )
 
@@ -168,9 +201,10 @@ pkg_npm(
         "package.json",
     ],
     deps = [
-        ":bazelisk-darwin-for-npm",
+        ":bazelisk-darwin-amd64-for-npm",
+        ":bazelisk-darwin-arm64-for-npm",
+        ":bazelisk-linux-amd64-for-npm",
         ":bazelisk-linux-arm64-for-npm",
-        ":bazelisk-linux-for-npm",
-        ":bazelisk-windows-for-npm",
+        ":bazelisk-windows-amd64-for-npm",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -112,6 +112,9 @@ genrule(
     outs = ["bazelisk-darwin_universal"],
     cmd = "lipo -create -output \"$@\" $(SRCS)",
     output_to_bindir = 1,
+    target_compatible_with = [
+        "@platforms//os:macos",
+    ],
 )
 
 go_binary(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,3 +58,13 @@ http_archive(
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 
 node_repositories()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz",
+    ],
+    sha256 = "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",
+)

--- a/build.sh
+++ b/build.sh
@@ -22,13 +22,17 @@ mkdir bin
 
 go build
 ./bazelisk build --config=release \
-    //:bazelisk-darwin \
-    //:bazelisk-linux \
+    //:bazelisk-darwin-amd64 \
+    //:bazelisk-darwin-arm64 \
+    //:bazelisk-darwin-universal \
+    //:bazelisk-linux-amd64 \
     //:bazelisk-linux-arm64 \
-    //:bazelisk-windows
+    //:bazelisk-windows-amd64
 echo
 
 cp bazel-out/*-opt-*/bin/bazelisk-darwin_amd64 bin/bazelisk-darwin-amd64
+cp bazel-out/*-opt-*/bin/bazelisk-darwin_arm64 bin/bazelisk-darwin-arm64
+cp bazel-out/*-opt/bin/bazelisk-darwin_universal bin/bazelisk-darwin
 cp bazel-out/*-opt-*/bin/bazelisk-linux_amd64 bin/bazelisk-linux-amd64
 cp bazel-out/*-opt-*/bin/bazelisk-linux_arm64 bin/bazelisk-linux-arm64
 cp bazel-out/*-opt-*/bin/bazelisk-windows_amd64.exe bin/bazelisk-windows-amd64.exe
@@ -36,7 +40,10 @@ rm -f bazelisk
 
 ### Build release artifacts using `go build`.
 # GOOS=linux GOARCH=amd64 go build -o bin/bazelisk-linux-amd64
+# GOOS=linux GOARCH=arm64 go build -o bin/bazelisk-linux-arm64
 # GOOS=darwin GOARCH=amd64 go build -o bin/bazelisk-darwin-amd64
+# GOOS=darwin GOARCH=arm64 go build -o bin/bazelisk-darwin-arm64
+# lipo -create -output bin/bazelisk-darwin bin/bazelisk-darwin-amd64 bin/bazelisk-darwin-arm64
 # GOOS=windows GOARCH=amd64 go build -o bin/bazelisk-windows-amd64.exe
 
 ### Print some information about the generated binaries.


### PR DESCRIPTION
With these changes, Bazelisk binaries for darwin-arm64 will be built.

Additionally, we build a universal Mac binary that can be used on amd64
and arm64 Macs and runs natively on either.