### PR TITLE
Make the HTTP user agent configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ It will set the environment variable `BAZEL_REAL` to the path of the downloaded 
 This can be useful, if you have a wrapper script that e.g. ensures that environment variables are set to known good values.
 This behavior can be disabled by setting the environment variable `BAZELISK_SKIP_WRAPPER` to any value (except the empty string) before launching Bazelisk.
 
+You can control the user agent that Bazelisk sends in all HTTP requests by setting `BAZELISK_USER_AGENT` to the desired value.
+
 # .bazeliskrc configuration file
 
 The Go version supports a `.bazeliskrc` file in the root directory of a workspace. This file allows users to set environment variables persistently.
@@ -127,6 +129,7 @@ The following variables can be set:
 - `BAZELISK_HOME`
 - `BAZELISK_SHUTDOWN`
 - `BAZELISK_SKIP_WRAPPER`
+- `BAZELISK_USER_AGENT`
 - `USE_BAZEL_VERSION`
 
 Please note that the actual environment variables take precedence over those in the `.bazeliskrc` file.

--- a/core/core.go
+++ b/core/core.go
@@ -43,6 +43,8 @@ var (
 
 // RunBazelisk runs the main Bazelisk logic for the given arguments and Bazel repositories.
 func RunBazelisk(args []string, repos *Repositories) (int, error) {
+	httputil.UserAgent = getUserAgent()
+
 	bazeliskHome := GetEnvOrConfig("BAZELISK_HOME")
 	if len(bazeliskHome) == 0 {
 		userCacheDir, err := os.UserCacheDir()
@@ -156,6 +158,14 @@ func RunBazelisk(args []string, repos *Repositories) (int, error) {
 		return -1, fmt.Errorf("could not run Bazel: %v", err)
 	}
 	return exitCode, nil
+}
+
+func getUserAgent() string {
+	agent := GetEnvOrConfig("BAZELISK_USER_AGENT")
+	if len(agent) > 0 {
+		return agent
+	}
+	return fmt.Sprintf("Bazelisk/%s", BazeliskVersion)
 }
 
 // GetEnvOrConfig reads a configuration value from the environment, but fall back to reading it from .bazeliskrc in the workspace root.


### PR DESCRIPTION
Until now Bazelisk has been using the default Go user agent when sending HTTP requests. Going forward Bazelisk will set a custom user agent that defaults to "Bazelisk/$version". Users can overwrite this value by setting the `BAZELISK_USER_AGENT` environment value.

