### PR TITLE
Use unsigned integer for shift count type

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -114,7 +114,7 @@ func getWaitPeriod(res *http.Response, attempt int) (time.Duration, error) {
 		}
 	}
 	// Let's just use exponential backoff: 1s + d1, 2s + d2, 4s + d3, 8s + d4 with dx being a random value in [0ms, 500ms]
-	return time.Duration(1 << attempt) * time.Second + time.Duration(rand.Intn(500)) * time.Millisecond, nil
+	return time.Duration(1 << uint(attempt)) * time.Second + time.Duration(rand.Intn(500)) * time.Millisecond, nil
 }
 
 func parseRetryHeader(value string) (time.Duration, error) {

--- a/httputil/httputil_test.go
+++ b/httputil/httputil_test.go
@@ -176,7 +176,7 @@ func TestShouldUseExponentialBackoffIfNoRetryHeader(t *testing.T) {
 	}
 
 	delta := time.Millisecond * 100
-	lower := (1 << retries) * time.Second
+	lower := (1 << uint(retries)) * time.Second
 	upper := lower + time.Duration(retries*500)*time.Millisecond
 	if total < lower-delta || upper+delta < total {
 		t.Fatalf("Expected a total sleep time between %s and %s (%d retries, exponential backoff with fuzzing), but waited %s instead", lower, upper, retries, total)


### PR DESCRIPTION
https://github.com/bazelbuild/bazelisk/pull/256 introduced an incompatible issue with Golang versions prior to 1.13:

```
github.com/bazelbuild/bazelisk/httputil/httputil.go:117:25: invalid operation: 1 << attempt (shift count type int, must be unsigned integer)
```

This PR fixes the issue by forcing the `attempt` variable as an unsigned integer.