### PR TITLE
suggest 'go install' instead of 'go get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ To install the Go version, type:
 ```shell
 go get github.com/bazelbuild/bazelisk
 ```
+With Go 1.17 or later, the recommended way to install it is:
+```shell
+go install github.com/bazelbuild/bazelisk@latest
+```
 
 To add it to your PATH:
 


### PR DESCRIPTION
https://golang.org/doc/go-get-install-deprecation - "Deprecation of 'go get' for installing executables" says that using `go get` for installing binaries is deprecated and will not be supported starting from go1.18. It would be good to get users to get used to the "new way" in advance.