### PR TITLE
Consider wrapper when only user- or group-executable

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -382,7 +382,7 @@ func maybeDelegateToWrapper(bazel string) string {
 
 	root := findWorkspaceRoot(wd)
 	wrapper := filepath.Join(root, wrapperPath)
-	if stat, err := os.Stat(wrapper); err != nil || stat.IsDir() || stat.Mode().Perm()&0001 == 0 {
+	if stat, err := os.Stat(wrapper); err != nil || stat.IsDir() || stat.Mode().Perm()&0111 == 0 {
 		return bazel
 	}
 


### PR DESCRIPTION
The bazel wrapper might not be executable by `other`, only
`user` or `group`, depending for instance on the umask of the
user.

Allow for this by checking the user and group executable bits
too. If the file is not executable by the current user, the
run will fail with permission denied.