### PR TITLE
Add support for patch versions of Bazel (e.g. `1.2.3-patch4`)

### DIFF
--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -35,6 +35,42 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestResolveVersion(t *testing.T) {
+	s := setUp(t)
+	s.AddVersion("4.0.0", false, nil, nil)
+	s.Finish()
+
+	gcs := &repositories.GCSRepo{}
+	repos := core.CreateRepositories(nil, gcs, nil, nil, nil, false)
+	version, _, err := repos.ResolveVersion(tmpDir, versions.BazelUpstream, "4.0.0")
+
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	expectedRC := "4.0.0"
+	if version != expectedRC {
+		t.Fatalf("Expected version %s, but got %s", expectedRC, version)
+	}
+}
+
+func TestResolvePatchVersion(t *testing.T) {
+	s := setUp(t)
+	s.AddVersion("4.0.0-patch1", false, nil, nil)
+	s.Finish()
+
+	gcs := &repositories.GCSRepo{}
+	repos := core.CreateRepositories(nil, gcs, nil, nil, nil, false)
+	version, _, err := repos.ResolveVersion(tmpDir, versions.BazelUpstream, "4.0.0-patch1")
+
+	if err != nil {
+		t.Fatalf("Version resolution failed unexpectedly: %v", err)
+	}
+	expectedRC := "4.0.0-patch1"
+	if version != expectedRC {
+		t.Fatalf("Expected version %s, but got %s", expectedRC, version)
+	}
+}
+
 func TestResolveLatestRcVersion(t *testing.T) {
 	s := setUp(t)
 	s.AddVersion("4.0.0", false, nil, nil)

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -18,6 +18,7 @@ const (
 
 var (
 	releasePattern       = regexp.MustCompile(`^(\d+)\.(x|\d+\.\d+)$`)
+	patchPattern         = regexp.MustCompile(`^(\d+\.\d+\.\d+)-([\w\d]+)$`)
 	candidatePattern     = regexp.MustCompile(`^(\d+\.\d+\.\d+)rc(\d+)$`)
 	rollingPattern       = regexp.MustCompile(`^\d+\.0\.0-pre\.\d{8}(\.\d+){1,2}$`)
 	latestReleasePattern = regexp.MustCompile(`^latest(?:-(?P<offset>\d+))?$`)
@@ -45,6 +46,8 @@ func Parse(fork, version string) (*Info, error) {
 			vi.IsRelative = true
 			vi.TrackRestriction = track
 		}
+	} else if patchPattern.MatchString(version) {
+		vi.IsRelease = true
 	} else if m := latestReleasePattern.FindStringSubmatch(version); m != nil {
 		vi.IsRelease = true
 		vi.IsRelative = true


### PR DESCRIPTION
I have some patches I maintain in a fork of Bazel and generate binaries with `-patch` suffixes followed by a number (e.g. `4.2.1-patch1`) and would like to start using Bazelisk to download those binaries. This mostly works already except that Bazelisk does not accept the `-patch` patch versions. The change is pretty small so thought I'd open a pull requests to learn whether or not this patching pattern was a good idea or if maybe there's a better way. I also understand not everyone may be doing this so am open to other ideas and approaches for using patched Bazel versions.