### PR TITLE
feat(platforms): fallback to x86_64 before bazel version 4.1.0 on App…

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -9,3 +9,9 @@ go_library(
         "@com_github_hashicorp_go_version//:go_default_library",
     ],
 )
+
+go_test(
+    name = "platforms_test",
+    srcs = ["platforms_test.go"],
+    embed = [":go_default_library"],
+)

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -5,4 +5,7 @@ go_library(
     srcs = ["platforms.go"],
     importpath = "github.com/bazelbuild/bazelisk/platforms",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_hashicorp_go_version//:go_default_library",
+    ],
 )

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -45,10 +45,7 @@ func DetermineBazelFilename(version string, includeSuffix bool) (string, error) 
 	}
 
 	if osName == "darwin" {
-		var err error
-		if machineName, err = DarwinFallback(machineName, version); err != nil {
-			return "", err
-		}
+		machineName = DarwinFallback(machineName, version)
 	}
 
 	var filenameSuffix string
@@ -60,19 +57,16 @@ func DetermineBazelFilename(version string, includeSuffix bool) (string, error) 
 }
 
 // DarwinFallback Darwin arm64 was supported since 4.1.0, before 4.1.0, fall back to x86_64
-func DarwinFallback(machineName string, version string) (alterMachineName string, err error) {
+func DarwinFallback(machineName string, version string) (alterMachineName string) {
 	v, err := sem_ver.NewVersion(version)
 	if err != nil {
-		return "", err
+		return machineName
 	}
 
-	armSupportVer, err := sem_ver.NewVersion("4.1.0")
-	if err != nil {
-		return "", err
-	}
+	armSupportVer, _ := sem_ver.NewVersion("4.1.0")
 
 	if machineName == "arm64" && v.LessThan(armSupportVer) {
-		return "x86_64", nil
+		return "x86_64"
 	}
-	return machineName, nil
+	return machineName
 }

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -3,7 +3,8 @@ package platforms
 
 import (
 	"fmt"
-	sem_ver "github.com/hashicorp/go-version"
+	semver "github.com/hashicorp/go-version"
+	"log"
 	"runtime"
 )
 
@@ -58,14 +59,15 @@ func DetermineBazelFilename(version string, includeSuffix bool) (string, error) 
 
 // DarwinFallback Darwin arm64 was supported since 4.1.0, before 4.1.0, fall back to x86_64
 func DarwinFallback(machineName string, version string) (alterMachineName string) {
-	v, err := sem_ver.NewVersion(version)
+	v, err := semver.NewVersion(version)
 	if err != nil {
 		return machineName
 	}
 
-	armSupportVer, _ := sem_ver.NewVersion("4.1.0")
+	armSupportVer, _ := semver.NewVersion("4.1.0")
 
 	if machineName == "arm64" && v.LessThan(armSupportVer) {
+		log.Printf("Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0")
 		return "x86_64"
 	}
 	return machineName

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -67,7 +67,7 @@ func DarwinFallback(machineName string, version string) (alterMachineName string
 	armSupportVer, _ := semver.NewVersion("4.1.0")
 
 	if machineName == "arm64" && v.LessThan(armSupportVer) {
-		log.Printf("Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0")
+		log.Printf("WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0")
 		return "x86_64"
 	}
 	return machineName

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -11,7 +11,6 @@ func TestDarwinFallback(t *testing.T) {
 		name                 string
 		args                 args
 		wantAlterMachineName string
-		wantErr              bool
 	}{
 		{
 			name: "before 4.1.0, x86_64 do not fallback",
@@ -20,7 +19,6 @@ func TestDarwinFallback(t *testing.T) {
 				version:     "4.0.1",
 			},
 			wantAlterMachineName: "x86_64",
-			wantErr:              false,
 		},
 		{
 			name: "since 4.1.0, x86_64 do not fallback either",
@@ -29,7 +27,6 @@ func TestDarwinFallback(t *testing.T) {
 				version:     "4.1.0",
 			},
 			wantAlterMachineName: "x86_64",
-			wantErr:              false,
 		},
 		{
 			name: "before 4.1.0, arm64 not supported, fallback to x86_64 on arm64",
@@ -38,7 +35,6 @@ func TestDarwinFallback(t *testing.T) {
 				version:     "4.0.1",
 			},
 			wantAlterMachineName: "x86_64",
-			wantErr:              false,
 		},
 		{
 			name: "since 4.1.0, arm64 supported, do not fallback",
@@ -47,16 +43,11 @@ func TestDarwinFallback(t *testing.T) {
 				version:     "4.1.0",
 			},
 			wantAlterMachineName: "arm64",
-			wantErr:              false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAlterMachineName, err := DarwinFallback(tt.args.machineName, tt.args.version)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("DarwinFallback() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			gotAlterMachineName := DarwinFallback(tt.args.machineName, tt.args.version)
 			if gotAlterMachineName != tt.wantAlterMachineName {
 				t.Errorf("DarwinFallback() gotAlterMachineName = %v, want %v", gotAlterMachineName, tt.wantAlterMachineName)
 			}

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -1,0 +1,65 @@
+package platforms
+
+import "testing"
+
+func TestDarwinFallback(t *testing.T) {
+	type args struct {
+		machineName string
+		version     string
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantAlterMachineName string
+		wantErr              bool
+	}{
+		{
+			name: "before 4.1.0, x86_64 do not fallback",
+			args: args{
+				machineName: "x86_64",
+				version:     "4.0.1",
+			},
+			wantAlterMachineName: "x86_64",
+			wantErr:              false,
+		},
+		{
+			name: "since 4.1.0, x86_64 do not fallback either",
+			args: args{
+				machineName: "x86_64",
+				version:     "4.1.0",
+			},
+			wantAlterMachineName: "x86_64",
+			wantErr:              false,
+		},
+		{
+			name: "before 4.1.0, arm64 not supported, fallback to x86_64 on arm64",
+			args: args{
+				machineName: "arm64",
+				version:     "4.0.1",
+			},
+			wantAlterMachineName: "x86_64",
+			wantErr:              false,
+		},
+		{
+			name: "since 4.1.0, arm64 supported, do not fallback",
+			args: args{
+				machineName: "arm64",
+				version:     "4.1.0",
+			},
+			wantAlterMachineName: "arm64",
+			wantErr:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAlterMachineName, err := DarwinFallback(tt.args.machineName, tt.args.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DarwinFallback() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotAlterMachineName != tt.wantAlterMachineName {
+				t.Errorf("DarwinFallback() gotAlterMachineName = %v, want %v", gotAlterMachineName, tt.wantAlterMachineName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
like #272 , add support to Apple Silicon.

fallback to x86_64 before bazel version 4.1.0 on Apple Silicon