### PR TITLE
Download native macOS arm64 binary on M1

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -13,7 +13,12 @@ var platforms = map[string]string{"darwin": "macos", "linux": "ubuntu1404", "win
 // GetPlatform returns a Bazel CI-compatible platform identifier for the current operating system.
 // TODO(fweikert): raise an error for unsupported platforms
 func GetPlatform() string {
-	return platforms[runtime.GOOS]
+	platform := platforms[runtime.GOOS]
+	arch := runtime.GOARCH
+	if platform == "macos" && arch == "arm64" {
+		platform = "macos_arm64"
+	}
+	return platform
 }
 
 // DetermineExecutableFilenameSuffix returns the extension for binaries on the current operating system.

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -15,8 +15,8 @@ var platforms = map[string]string{"darwin": "macos", "linux": "ubuntu1404", "win
 func GetPlatform() string {
 	platform := platforms[runtime.GOOS]
 	arch := runtime.GOARCH
-	if platform == "macos" && arch == "arm64" {
-		platform = "macos_arm64"
+	if arch == "arm64" {
+		platform = platform + "_arm64"
 	}
 	return platform
 }

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 
 	"github.com/bazelbuild/bazelisk/httputil"
@@ -236,6 +237,11 @@ func (gcs *GCSRepo) GetLastGreenCommit(bazeliskHome string, downstreamGreen bool
 // DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
 func (gcs *GCSRepo) DownloadAtCommit(commit, destDir, destFile string) (string, error) {
 	log.Printf("Using unreleased version at commit %s", commit)
-	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platforms.GetPlatform(), commit)
+	platform := platforms.GetPlatform()
+	arch := runtime.GOARCH
+	if platform == "macos" && arch == "arm64" {
+		platform = "macos_arm64"
+	}
+	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platform, commit)
 	return httputil.DownloadBinary(url, destDir, destFile)
 }

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"runtime"
 	"strings"
 
 	"github.com/bazelbuild/bazelisk/httputil"
@@ -237,11 +236,6 @@ func (gcs *GCSRepo) GetLastGreenCommit(bazeliskHome string, downstreamGreen bool
 // DownloadAtCommit downloads a Bazel binary built at the given commit into the specified location and returns the absolute path.
 func (gcs *GCSRepo) DownloadAtCommit(commit, destDir, destFile string) (string, error) {
 	log.Printf("Using unreleased version at commit %s", commit)
-	platform := platforms.GetPlatform()
-	arch := runtime.GOARCH
-	if platform == "macos" && arch == "arm64" {
-		platform = "macos_arm64"
-	}
-	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platform, commit)
+	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platforms.GetPlatform(), commit)
 	return httputil.DownloadBinary(url, destDir, destFile)
 }

--- a/test.sh
+++ b/test.sh
@@ -4,14 +4,14 @@ set -euxo pipefail
 
 rm -rf "$HOME/Library/Caches/bazelisk"
 
-readonly arch=$(uname -m)
-env -u USE_BAZEL_VERSION ./bin/bazelisk-darwin-$arch version
-USE_BAZEL_VERSION="latest" ./bin/bazelisk-darwin-$arch version
+arch=$(uname -m)
+env -u USE_BAZEL_VERSION ./bin/bazelisk-darwin-"$arch" version
+USE_BAZEL_VERSION="latest" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="0.28.0" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="last_green" ./bin/bazelisk-darwin-$arch version
-USE_BAZEL_VERSION="last_downstream_green" ./bin/bazelisk-darwin-$arch version
-USE_BAZEL_VERSION="last_rc" ./bin/bazelisk-darwin-$arch version
-USE_BAZEL_VERSION="bazelbuild/latest" ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="last_green" ./bin/bazelisk-darwin-"$arch" version
+USE_BAZEL_VERSION="last_downstream_green" ./bin/bazelisk-darwin-"$arch" version
+USE_BAZEL_VERSION="last_rc" ./bin/bazelisk-darwin-"$arch" version
+USE_BAZEL_VERSION="bazelbuild/latest" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="bazelbuild/0.27.0" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="philwo/latest" ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="philwo/latest" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="philwo/0.25.0" ./bin/bazelisk-darwin-amd64 version

--- a/test.sh
+++ b/test.sh
@@ -3,13 +3,15 @@
 set -euxo pipefail
 
 rm -rf "$HOME/Library/Caches/bazelisk"
-env -u USE_BAZEL_VERSION ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="latest" ./bin/bazelisk-darwin-amd64 version
+
+readonly arch=$(uname -m)
+env -u USE_BAZEL_VERSION ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="latest" ./bin/bazelisk-darwin-$arch version
 USE_BAZEL_VERSION="0.28.0" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="last_green" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="last_downstream_green" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="last_rc" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="bazelbuild/latest" ./bin/bazelisk-darwin-amd64 version
+USE_BAZEL_VERSION="last_green" ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="last_downstream_green" ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="last_rc" ./bin/bazelisk-darwin-$arch version
+USE_BAZEL_VERSION="bazelbuild/latest" ./bin/bazelisk-darwin-$arch version
 USE_BAZEL_VERSION="bazelbuild/0.27.0" ./bin/bazelisk-darwin-amd64 version
-USE_BAZEL_VERSION="philwo/latest" ./bin/bazelisk-darwin-amd64 version
+USE_BAZEL_VERSION="philwo/latest" ./bin/bazelisk-darwin-$arch version
 USE_BAZEL_VERSION="philwo/0.25.0" ./bin/bazelisk-darwin-amd64 version


### PR DESCRIPTION
When using macOS on M1 and downloading a commit or any keyword that resolves to a commit (e.g., `last_green`) `bazelisk` was downloading from the url: `https://storage.googleapis.com/bazel-builds/artifacts/macos/[commit]/bazel`.

This PR changes the url to be of the form: `https://storage.googleapis.com/bazel-builds/artifacts/macos_arm64/[commit]/bazel`.

Also, to get tests to now pass on M1, `test.sh` has been updated to insert the arch determined from `uname -m` for the versions that support `arm64`.

See: https://github.com/bazelbuild/continuous-integration/issues/1338