### PR TITLE
Fetch rolling releases from GCS

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -26,9 +26,8 @@ import (
 func main() {
 	gcs := &repositories.GCSRepo{}
 	gitHub := repositories.CreateGitHubRepo(core.GetEnvOrConfig("BAZELISK_GITHUB_TOKEN"))
-	// Fetch LTS releases, release candidates and Bazel-at-commits from GCS, forks and rolling releases from GitHub.
-	// TODO(https://github.com/bazelbuild/bazelisk/issues/228): get rolling releases from GCS, too.
-	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gitHub, true)
+	// Fetch LTS releases, release candidates, rolling releases and Bazel-at-commits from GCS, forks from GitHub.
+	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
 
 	exitCode, err := core.RunBazelisk(os.Args[1:], repos)
 	if err != nil {

--- a/repositories/github.go
+++ b/repositories/github.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bazelbuild/bazelisk/httputil"
 	"github.com/bazelbuild/bazelisk/platforms"
-	"github.com/bazelbuild/bazelisk/versions"
 )
 
 const (
@@ -88,15 +87,4 @@ func (gh *GitHubRepo) DownloadVersion(fork, version, destDir, destFile string) (
 	}
 	url := fmt.Sprintf(urlPattern, fork, version, filename)
 	return httputil.DownloadBinary(url, destDir, destFile)
-}
-
-// GetRollingVersions returns a list of all available rolling release versions.
-func (gh *GitHubRepo) GetRollingVersions(bazeliskHome string) ([]string, error) {
-	// Release candidates are uploaded to GCS only, which means that all prerelease binaries on GitHub belong to rolling releases.
-	return gh.getFilteredVersions(bazeliskHome, versions.BazelUpstream, true)
-}
-
-// DownloadRolling downloads the given Bazel version into the specified location and returns the absolute path.
-func (gh *GitHubRepo) DownloadRolling(version, destDir, destFile string) (string, error) {
-	return gh.DownloadVersion(versions.BazelUpstream, version, destDir, destFile)
 }


### PR DESCRIPTION
Closes https://github.com/bazelbuild/bazelisk/issues/228

Has the benefit of avoiding github rate limits on github actions when using rolling releases