### PR TITLE
Stop forwarding SIGINT to child processes

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -438,9 +437,9 @@ func runBazel(bazel string, args []string, out io.Writer) (int, error) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		s := <-c
-		if runtime.GOOS != "windows" {
-			cmd.Process.Signal(s)
-		} else {
+
+		// Only forward SIGTERM to our child process.
+		if s != os.Interrupt {
 			cmd.Process.Kill()
 		}
 	}()


### PR DESCRIPTION


---

#### Commits _(oldest to newest)_

22c287a Stop forwarding SIGINT to child processes

Since we handle os.Interrupt but no longer forward it to child
processes, this commit also removes platform-specific handling for
Windows, preferring to use child.Process.Kill() in all cases.

Fixes #307.

<br/>