### PR TITLE
Allow any execute bits to count as executable

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -410,7 +410,7 @@ func maybeDelegateToWrapper(bazel string) string {
 
 	root := findWorkspaceRoot(wd)
 	wrapper := filepath.Join(root, wrapperPath)
-	if stat, err := os.Stat(wrapper); err != nil || stat.IsDir() || stat.Mode().Perm()&0001 == 0 {
+	if stat, err := os.Stat(wrapper); err != nil || stat.IsDir() || stat.Mode().Perm()&0111 == 0 {
 		return bazel
 	}
 


### PR DESCRIPTION
If the `tools/bazel` wrapper is executable by the user, but not everyone the current behavior is that `bazelisk` assumes it's not executable and silently pretends that the wrapper script doesn't exist, which was very confusing to me.

After this change, someone could run into the case where `bazelisk` thinks the user can execute the wrapper, but doesn't actually have permission. If that does happen, the error `could not run Bazel: could not start Bazel: fork/exec /repo/tools/bazel: permission denied` makes it pretty clear what's wrong.

This now matches how the Go standard library checks if a file is executable. https://cs.opensource.google/go/go/+/refs/tags/go1.19:src/os/exec/lp_unix.go;l=26