### PR TITLE
Support BAZELISK_INCOMPATIBLE_FLAGS for explicitly setting incompatible flags to be tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ bazelisk --strict build //...
 If the code fails with `--strict`, the flag `--migrate` will run Bazel with each one of the flag separately, and print a report at the end.
 This will show you which flags can safely enabled, and which flags require a migration.
 
+You can set `BAZELISK_INCOMPATIBLE_FLAGS` to set a list of incompatible flags (separated by `,`) to be tested, otherwise Bazelisk tests all flags starting with `--incompatible_`.
+
 You can set `BAZELISK_GITHUB_TOKEN` to set a GitHub access token to use for API requests to avoid rate limiting when on shared networks.
 
 You can set `BAZELISK_SHUTDOWN` to run `shutdown` between builds when migrating if you suspect this affects your results.
@@ -144,6 +146,7 @@ The following variables can be set:
 - `BAZELISK_CLEAN`
 - `BAZELISK_GITHUB_TOKEN`
 - `BAZELISK_HOME`
+- `BAZELISK_INCOMPATIBLE_FLAGS`
 - `BAZELISK_SHUTDOWN`
 - `BAZELISK_SKIP_WRAPPER`
 - `BAZELISK_USER_AGENT`

--- a/core/core.go
+++ b/core/core.go
@@ -486,6 +486,11 @@ func runBazel(bazel string, args []string, out io.Writer) (int, error) {
 
 // getIncompatibleFlags returns all incompatible flags for the current Bazel command in alphabetical order.
 func getIncompatibleFlags(bazelPath, cmd string) ([]string, error) {
+	var incompatible_flags_str = GetEnvOrConfig("BAZELISK_INCOMPATIBLE_FLAGS")
+	if len(incompatible_flags_str) > 0 {
+		return strings.Split(incompatible_flags_str, ","), nil
+	}
+
 	out := strings.Builder{}
 	if _, err := runBazel(bazelPath, []string{"help", cmd, "--short"}, &out); err != nil {
 		return nil, fmt.Errorf("unable to determine incompatible flags with binary %s: %v", bazelPath, err)


### PR DESCRIPTION
This makes testing incompatible flags more flexible, both on CI or on users' local machines.

Working towards https://github.com/bazelbuild/continuous-integration/issues/1410