### PR TITLE
Fix performance issue for floating version values

### DIFF
--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -166,7 +166,7 @@ func TestResolveLatestVersion_ShouldFailIfNotEnoughReleases(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected ResolveVersion() to fail.")
 	}
-	expectedError := "unable to determine latest version: requested 2 latest releases, but only found 1"
+	expectedError := "cannot resolve version \"latest-1\": There are not enough matching Bazel releases (1)"
 	if err.Error() != expectedError {
 		t.Fatalf("Expected error message %q, but got '%v'", expectedError, err)
 	}

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/repositories",
     visibility = ["//visibility:public"],
     deps = [
+        "//core:go_default_library",
         "//httputil:go_default_library",
         "//platforms:go_default_library",
         "//versions:go_default_library",


### PR DESCRIPTION
Using a floating version such as "5.x" previously meant that Bazelisk would send O(LTS releases) requests to GCS, thus resulting in noticeable lag.

This commit changes the code so that floating versions exploit a "stop early" optimization similar to the "last N" use case, thus resulting in significantly fewer GCS requests (from 106 down to two).

Fixes https://github.com/bazelbuild/bazelisk/issues/339