### PR TITLE
Use Linux binaries built on CentOS 7

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -20,7 +20,7 @@ var supportedPlatforms = map[string]*platform{
 		HasArm64Binary: true,
 	},
 	"linux": {
-		Name:           "ubuntu1804",
+		Name:           "centos7",
 		HasArm64Binary: false,
 	},
 	"windows": {


### PR DESCRIPTION
As a result, Bazelisk should work on Ubuntu 14.04 and 16.04 again. Moreover, CentOS 7 is the most likely candidate for publishing arm64 Bazel binaries in the future.