### PR TITLE
Eliminate use of deprecated `distutils.version` module

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import base64
 from contextlib import closing
-from distutils.version import LooseVersion
 import hashlib
 import json
 import netrc
@@ -171,15 +170,18 @@ def read_remote_text_file(url):
 
 
 def get_version_history(bazelisk_directory):
-    ordered = sorted(
+    return sorted(
         (
-            LooseVersion(release["tag_name"])
+            release["tag_name"]
             for release in get_releases_json(bazelisk_directory)
             if not release["prerelease"]
         ),
+        # This only handles versions with numeric components, but that is fine
+        # since prerelease versions have been excluded.
+        key=lambda version: tuple(int(component)
+                                  for component in version.split('.')),
         reverse=True,
     )
-    return [str(v) for v in ordered]
 
 
 def resolve_latest_version(version_history, offset):


### PR DESCRIPTION
Since the recommended replacement, `packaging.version`, is not in the standard library, this commit instead just implements a simple version number comparison without any additional dependencies.