### PR TITLE
Support user `.bazeliskrc` in addition to workspace root `.bazeliskrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can control the user agent that Bazelisk sends in all HTTP requests by setti
 
 # .bazeliskrc configuration file
 
-The Go version supports a `.bazeliskrc` file in the root directory of a workspace. This file allows users to set environment variables persistently.
+The Go version supports a `.bazeliskrc` file in the root directory of a workspace and the user home directory. This file allows users to set environment variables persistently.
 
 Example file content:
 
@@ -151,7 +151,11 @@ The following variables can be set:
 - `BAZELISK_USER_AGENT`
 - `USE_BAZEL_VERSION`
 
-Please note that the actual environment variables take precedence over those in the `.bazeliskrc` file.
+Configuration variables are evaluated with precedence order. The preferred values are derived in order from highest to lowest precedence as follows:
+
+* Variables defined in the environment
+* Variables defined in the workspace root `.bazeliskrc`
+* Variables defined in the user home `.bazeliskrc`
 
 ## Requirements
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -150,6 +150,7 @@ function test_bazel_version_from_user_home_bazeliskrc() {
 
   BAZELISK_HOME="$BAZELISK_HOME" \
       HOME="$USER_HOME" \
+      USERPROFILE="$USER_HOME" \
       bazelisk version 2>&1 | tee log
 
   grep "Build label: 0.19.0" log || \
@@ -164,6 +165,7 @@ function test_bazel_version_prefer_workspace_bazeliskrc_to_user_home_bazeliskrc(
 
   BAZELISK_HOME="$BAZELISK_HOME" \
       HOME="$USER_HOME" \
+      USERPROFILE="$USER_HOME" \
       bazelisk version 2>&1 | tee log
 
   grep "Build label: 0.19.0" log || \


### PR DESCRIPTION
This change introduces support for locating multiple `.bazeliskrc` files, namely, in the workspace root and in the user home (`~/`) directory. Configuration in the former takes precedence over the latter. Semantically, this operates similarly to `.bazelrc`.

This change is backwards-compatible and does not introduce any new behaviors when there is only a single `.bazeliskrc` in the workspace.

The motivation is that I have some configuration (namely, `BAZELISK_BASE_URL`) that I'd like to set globally rather than versioning a `.bazeliskrc` into every Bazel project.

Concretely, here I have:

* Split out `GetEnvOrConfig` into multiple subroutines for locating the relevant RC files, parsing them individually, and loading them into the global configuration map, respecting precedence.
* Restructured existing logic to add `error` returns in the function signature of the above subroutines, and handle this appropriately during the loading phase.
* Added a constant for the `".bazeliskrc"` name.
* Added integration tests to verify the new behavior.