### PR TITLE
Suppress Apple Silicon fallback warning for commits.

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/platforms",
     visibility = ["//visibility:public"],
     deps = [
+        "//versions:go_default_library",
         "@com_github_hashicorp_go_version//:go_default_library",
     ],
 )

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"runtime"
 
+	"github.com/bazelbuild/bazelisk/versions"
 	semver "github.com/hashicorp/go-version"
 )
 
@@ -87,6 +88,11 @@ func DetermineBazelFilename(version string, includeSuffix bool) (string, error) 
 
 // DarwinFallback Darwin arm64 was supported since 4.1.0, before 4.1.0, fall back to x86_64
 func DarwinFallback(machineName string, version string) (alterMachineName string) {
+	// Do not use fallback for commits since they are likely newer than Bazel 4.1
+	if versions.IsCommit(version) {
+		return machineName
+	}
+
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		return machineName

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -105,3 +105,8 @@ func GetInAscendingOrder(versions []string) []string {
 	}
 	return sorted
 }
+
+// IsCommit returns whether the given version refers to a commit.
+func IsCommit(version string) bool {
+	return version == "last_green" || version == "last_downstream_green" || commitPattern.MatchString(version)
+}


### PR DESCRIPTION
Bazelisk on M1 always printed "Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0" when asking for a Bazel binary built at a commit. However, the code downloaded the ARM64 binary regardless (which was the correct behavior given that commits are very likely newer than Bazel 4.1).

This commit suppresses the warning message in this case.

Fixes https://github.com/bazelbuild/bazelisk/issues/391