### PR TITLE
Fix 'file name too long' errors on darwin

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -30,6 +31,7 @@ const (
 	skipWrapperEnv = "BAZELISK_SKIP_WRAPPER"
 	wrapperPath    = "./tools/bazel"
 	rcFileName     = ".bazeliskrc"
+	maxDirLength   = 255
 )
 
 var (
@@ -729,5 +731,12 @@ func migrate(bazelPath string, baseArgs []string, flags []string) {
 
 func dirForURL(url string) string {
 	// Replace all characters that might not be allowed in filenames with "-".
-	return regexp.MustCompile("[[:^alnum:]]").ReplaceAllString(url, "-")
+	dir := regexp.MustCompile("[[:^alnum:]]").ReplaceAllString(url, "-")
+	// Work around length limit on some systems by truncating and then appending
+	// a sha256 hash of the URL.
+	if len(dir) > maxDirLength {
+		suffix := fmt.Sprintf("...%x", sha256.Sum256([]byte(url)))
+		dir = dir[:maxDirLength-len(suffix)] + suffix
+	}
+	return dir
 }


### PR DESCRIPTION
`dirForURL` results in a "file name too long" error when using a path to a Bazel binary that is deeply nested in the FS as the bazel "version". This can happen in bazel integration tests that are using a static bazel binary, invoked via bazelisk.

Example failure: https://app.buildbuddy.io/invocation/11a56209-bdd7-412a-9a62-bda96f798117?target=%2F%2Fcli%2Ftest%2Fintegration%2Fcli%3Acli_test

`failed to run bazelisk: cound not link local Bazel: could not create directory /Users/administrator/buildbuddy.noindex/remote_build/11f02b5f-336d-4ce7-a01f-8b79df00fde9/output-base/sandbox/darwin-sandbox/2/execroot/buildbuddy/_tmp/e5ca0d86ab06654b9dcb40c80ba5e589/buildbuddy-test-1985373647/Library/Caches/bazelisk/local/-Users-administrator-buildbuddy-noindex-remote-build-11f02b5f-336d-4ce7-a01f-8b79df00fde9-output-base-sandbox-darwin-sandbox-2-execroot-buildbuddy-bazel-out-darwin-fastbuild-bin-cli-test-integration-cli-cli-test--cli-test-runfiles-buildbuddy-server-util-bazel-bazel-5-3-0/bin: mkdir /Users/administrator/buildbuddy.noindex/remote_build/11f02b5f-336d-4ce7-a01f-8b79df00fde9/output-base/sandbox/darwin-sandbox/2/execroot/buildbuddy/_tmp/e5ca0d86ab06654b9dcb40c80ba5e589/buildbuddy-test-1985373647/Library/Caches/bazelisk/local/-Users-administrator-buildbuddy-noindex-remote-build-11f02b5f-336d-4ce7-a01f-8b79df00fde9-output-base-sandbox-darwin-sandbox-2-execroot-buildbuddy-bazel-out-darwin-fastbuild-bin-cli-test-integration-cli-cli-test--cli-test-runfiles-buildbuddy-server-util-bazel-bazel-5-3-0: file name too long`