### PR TITLE
Support aarch64 in `bazelisk.py`.

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -258,7 +258,7 @@ def normalized_machine_arch_name():
     machine = platform.machine().lower()
     if machine == "amd64":
         machine = "x86_64"
-    if machine == "aarch64":
+    elif machine == "aarch64":
         machine = "arm64"
     return machine
 

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -258,6 +258,8 @@ def normalized_machine_arch_name():
     machine = platform.machine().lower()
     if machine == "amd64":
         machine = "x86_64"
+    if machine == "aarch64":
+        machine = "arm64"
     return machine
 
 


### PR DESCRIPTION
Linux reports arm64 as aarch64. Correct for this so that Bazel can be fetched when on arm64/aarch64.