### PR TITLE
Bump go, rules_go, and bazel_gazelle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -102,8 +102,8 @@ go_binary(
 genrule(
     name = "bazelisk-darwin-universal",
     srcs = [
-        ":bazelisk-darwin_amd64",
-        ":bazelisk-darwin_arm64",
+        ":bazelisk-darwin-amd64",
+        ":bazelisk-darwin-arm64",
     ],
     outs = ["bazelisk-darwin_universal"],
     cmd = "lipo -create -output \"$@\" $(SRCS)",
@@ -151,61 +151,21 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "bazelisk-darwin-amd64-for-npm",
-    srcs = [":bazelisk-darwin-amd64"],
-    outs = ["bazelisk-darwin_amd64"],
-    cmd = "cp $(location :bazelisk-darwin-amd64) \"$@\"",
-    output_to_bindir = 1,
-)
-
-genrule(
-    name = "bazelisk-darwin-arm64-for-npm",
-    srcs = [":bazelisk-darwin-arm64"],
-    outs = ["bazelisk-darwin_arm64"],
-    cmd = "cp $(location :bazelisk-darwin-arm64) \"$@\"",
-    output_to_bindir = 1,
-)
-
-genrule(
-    name = "bazelisk-linux-amd64-for-npm",
-    srcs = [":bazelisk-linux-amd64"],
-    outs = ["bazelisk-linux_amd64"],
-    cmd = "cp $(location :bazelisk-linux-amd64) \"$@\"",
-    output_to_bindir = 1,
-)
-
-genrule(
-    name = "bazelisk-linux-arm64-for-npm",
-    srcs = [":bazelisk-linux-arm64"],
-    outs = ["bazelisk-linux_arm64"],
-    cmd = "cp $(location :bazelisk-linux-arm64) \"$@\"",
-    output_to_bindir = 1,
-)
-
-genrule(
-    name = "bazelisk-windows-amd64-for-npm",
-    srcs = [":bazelisk-windows-amd64"],
-    outs = ["bazelisk-windows_amd64.exe"],
-    cmd = "cp $(location :bazelisk-windows-amd64) \"$@\"",
-    output_to_bindir = 1,
-)
-
 pkg_npm(
     name = "npm_package",
     package_name = "@bazel/bazelisk",
     srcs = [
         "LICENSE",
         "README.md",
-        "bazelisk.js",
         "bazelisk.d.ts",
+        "bazelisk.js",
         "package.json",
     ],
     deps = [
-        ":bazelisk-darwin-amd64-for-npm",
-        ":bazelisk-darwin-arm64-for-npm",
-        ":bazelisk-linux-amd64-for-npm",
-        ":bazelisk-linux-arm64-for-npm",
-        ":bazelisk-windows-amd64-for-npm",
+        ":bazelisk-darwin-amd64",
+        ":bazelisk-darwin-arm64",
+        ":bazelisk-linux-amd64",
+        ":bazelisk-linux-arm64",
+        ":bazelisk-windows-amd64",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,15 +24,15 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 go_repository(
     name = "com_github_bazelbuild_rules_go",
     importpath = "github.com/bazelbuild/rules_go",
-    sum = "h1:KViqR7qKXwz+LrNdIauCDU21kneCk+4DnYjpvlJwH50=",
-    version = "v0.27.0",
+    sum = "h1:hKvFRTyZEoHeIjPe/Kd8RL9cP9s3hoeMlO8vywdXSfY=",
+    version = "v0.36.0",
 )
 
 go_repository(
     name = "com_github_hashicorp_go_version",
     importpath = "github.com/hashicorp/go-version",
-    sum = "h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=",
-    version = "v1.3.0",
+    sum = "h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=",
+    version = "v1.6.0",
 )
 
 go_repository(
@@ -52,7 +52,7 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19.3")
+go_register_toolchains(version = "1.19.4")
 
 gazelle_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ae013bf35bd23234d1dea46b079f1e05ba74ac0321423830119d3e787ec73483",
+    sha256 = "56d8c5a5c91e1af73eca71a6fab2ced959b67c86d12ba37feedb0a2dfea441a6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.37.0/rules_go-v0.37.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.37.0/rules_go-v0.37.0.zip",
     ],
 )
 
@@ -24,8 +24,8 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 go_repository(
     name = "com_github_bazelbuild_rules_go",
     importpath = "github.com/bazelbuild/rules_go",
-    sum = "h1:hKvFRTyZEoHeIjPe/Kd8RL9cP9s3hoeMlO8vywdXSfY=",
-    version = "v0.36.0",
+    sum = "h1:vbnESGv/t2WgGEbXatwbXAS95dTx93Lv6Uh5QkVF13s=",
+    version = "v0.37.0",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    sha256 = "ae013bf35bd23234d1dea46b079f1e05ba74ac0321423830119d3e787ec73483",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.36.0/rules_go-v0.36.0.zip",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,7 +52,7 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.16.4")
+go_register_toolchains(version = "1.19.3")
 
 gazelle_dependencies()
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/bazelbuild/bazelisk
 
-go 1.15
+go 1.18
 
 require (
-	github.com/bazelbuild/rules_go v0.34.0
+	github.com/bazelbuild/rules_go v0.36.0
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/go-version v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bazelbuild/bazelisk
 go 1.18
 
 require (
-	github.com/bazelbuild/rules_go v0.36.0
+	github.com/bazelbuild/rules_go v0.37.0
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/hashicorp/go-version v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bazelbuild/rules_go v0.34.0 h1:cmObMtgIOaEU944SqXtJ9DnlS8IPGGa7pdRnsrpQzXM=
-github.com/bazelbuild/rules_go v0.34.0/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
+github.com/bazelbuild/rules_go v0.36.0 h1:hKvFRTyZEoHeIjPe/Kd8RL9cP9s3hoeMlO8vywdXSfY=
+github.com/bazelbuild/rules_go v0.36.0/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bazelbuild/rules_go v0.36.0 h1:hKvFRTyZEoHeIjPe/Kd8RL9cP9s3hoeMlO8vywdXSfY=
-github.com/bazelbuild/rules_go v0.36.0/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
+github.com/bazelbuild/rules_go v0.37.0 h1:vbnESGv/t2WgGEbXatwbXAS95dTx93Lv6Uh5QkVF13s=
+github.com/bazelbuild/rules_go v0.37.0/go.mod h1:TMHmtfpvyfsxaqfL9WnahCsXMWDMICTw7XeK9yVb+YU=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=


### PR DESCRIPTION
Certain vulnerability scanners will flag bazelisk for being built with an outdated golang toolchain. To remediate this, update to the latest version of the go toolchain (1.19.3). Upgrade to the latest major version since 1.16 is EOL.

Also upgrades `rules_go` to `0.36.0` and `bazel_gazelle` to `0.28.0`. At the same time, removes the workaround to get output binaries placed into the appropriate directory since it's no longer necessary.