### PR TITLE
fix: don't pass auth token in getFilteredVersions with BAZELISK_GITHUB_TOKEN is unset

### DIFF
--- a/repositories/github.go
+++ b/repositories/github.go
@@ -52,7 +52,11 @@ func (gh *GitHubRepo) getFilteredVersions(bazeliskHome, bazelFork string, wantPr
 	}
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/bazel/releases", bazelFork)
-	releasesJSON, err := httputil.MaybeDownload(bazeliskHome, url, bazelFork+"-releases.json", "list of Bazel releases from github.com/"+bazelFork, fmt.Sprintf("token %s", gh.token), merger)
+	auth := ""
+	if gh.token != "" {
+		auth = fmt.Sprintf("token %s", gh.token)
+	}
+	releasesJSON, err := httputil.MaybeDownload(bazeliskHome, url, bazelFork+"-releases.json", "list of Bazel releases from github.com/"+bazelFork, auth, merger)
 	if err != nil {
 		return []string{}, fmt.Errorf("unable to determine '%s' releases: %v", bazelFork, err)
 	}


### PR DESCRIPTION
I tested this locally with a `.bazeliskrc` file with the following contents:
```
USE_BAZEL_VERSION=aspect-cli/latest
```
This will get the latest release from https://github.com/aspect-cli/bazel/releases.