### PR TITLE
Generate sha256 message digest for built binaries

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//:def.bzl", "sha256sum")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk
 gazelle(name = "gazelle")
@@ -85,6 +86,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+sha256sum(
+   name = "bazelisk-darwin-amd64-sha",
+   src = ":bazelisk-darwin-amd64",
+)
+
 go_binary(
     name = "bazelisk-darwin-arm64",
     out = "bazelisk-darwin_arm64",
@@ -97,6 +103,11 @@ go_binary(
     goos = "darwin",
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+sha256sum(
+   name = "bazelisk-darwin-arm64-sha",
+   src = ":bazelisk-darwin-arm64",
 )
 
 genrule(
@@ -113,6 +124,11 @@ genrule(
     ],
 )
 
+sha256sum(
+   name = "bazelisk-darwin-universal-sha",
+   src = ":bazelisk-darwin-universal",
+)
+
 go_binary(
     name = "bazelisk-linux-amd64",
     out = "bazelisk-linux_amd64",
@@ -125,6 +141,11 @@ go_binary(
     goos = "linux",
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+sha256sum(
+   name = "bazelisk-linux-amd64-sha",
+   src = ":bazelisk-linux-amd64",
 )
 
 go_binary(
@@ -141,6 +162,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+sha256sum(
+   name = "bazelisk-linux-arm64-sha",
+   src = ":bazelisk-linux-arm64",
+)
+
 go_binary(
     name = "bazelisk-windows-amd64",
     out = "bazelisk-windows_amd64.exe",
@@ -149,6 +175,11 @@ go_binary(
     goos = "windows",
     pure = "on",
     visibility = ["//visibility:public"],
+)
+
+sha256sum(
+   name = "bazelisk-windows-amd64-sha",
+   src = ":bazelisk-windows-amd64",
 )
 
 pkg_npm(

--- a/def.bzl
+++ b/def.bzl
@@ -1,0 +1,27 @@
+def _sha256sum_impl(ctx):
+  ctx.actions.run_shell(
+    outputs = [ctx.outputs.sha256],
+    inputs = [ctx.file.src],
+    command = "CWD=$PWD && cd `dirname {0}` && sha256sum `basename {0}` > $CWD/{1}".format(ctx.file.src.path, ctx.outputs.sha256.path),
+  )
+
+  return DefaultInfo(files = depset([ctx.outputs.sha256]))
+
+_sha256sum = rule(
+  implementation = _sha256sum_impl,
+  attrs = {
+    "src": attr.label(mandatory = True, allow_single_file = True),
+    "sha256": attr.output(),
+  }
+)
+
+def sha256sum(name, src, **kwargs):
+  """
+  Macro to create a sha256 message digest file
+  """
+  _sha256sum(
+    name = name,
+    src = src,
+    sha256 = "%s.sha256" % src,
+    **kwargs,
+  )


### PR DESCRIPTION
Relates to #306 

This work generates files that contain the sha256 message digest for each binary. I'm not sure how you go about populating artifacts to the github release but would be able to do it if someone could point me in the right direction.