### PR TITLE
Normalize machine arch name aarch64 to arm64

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -258,6 +258,8 @@ def normalized_machine_arch_name():
     machine = platform.machine().lower()
     if machine == "amd64":
         machine = "x86_64"
+    if machine == "aarch64":
+        machine = "arm64"
     return machine
 
 


### PR DESCRIPTION
Since about 3 days ago, we started [having trouble installing tensorstore on ARM](https://github.com/google/tensorstore/issues/77). Normalizing 'aarch64' to 'arm64' should fix the issue.