### PR TITLE
Support `BAZELISK_NOJDK` in Bazelisk Go. Fix #267 and #430

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -44,6 +44,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk",
     visibility = ["//visibility:private"],
     deps = [
+        "//configs:go_default_library",
         "//core:go_default_library",
         "//repositories:go_default_library",
     ],

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Frontend developers may want to install it with `npm install -g @bazel/bazelisk`
 > [`nvm` utility](https://github.com/nvm-sh/nvm) which manages your version of Node.js.
 
 Some ideas how to use it:
+
 - Install it as the `bazel` binary in your `PATH` (e.g. copy it to `/usr/local/bin/bazel`).
   Never worry about upgrading Bazel to the latest version again.
 - Check it into your repository and recommend users to build your software via `./bazelisk build //my:software`.
@@ -42,6 +43,7 @@ The documentation below describes the newer Go version only.
 ## How does Bazelisk know which Bazel version to run?
 
 It uses a simple algorithm:
+
 - If the environment variable `USE_BAZEL_VERSION` is set, it will use the version specified in the value.
 - Otherwise, if a `.bazeliskrc` file exists in the workspace root and contains the `USE_BAZEL_VERSION` variable, this version will be used.
 - Otherwise, if a `.bazelversion` file exists in the current directory or recursively any parent directory, it will read the file and use the version specified in it.
@@ -55,7 +57,10 @@ A version can optionally be prefixed with a fork name.
 The fork and version should be separated by slash: `<FORK>/<VERSION>`.
 Please see the next section for how to work with forks.
 
+If `BAZELISK_NOJDK` is set in environment variable or `.bazeliskrc` to `1`, bazelisk will use the `nojdk` version of bazel.
+
 Bazelisk currently understands the following formats for version labels:
+
 - `latest` means the latest stable (LTS) version of Bazel as released on GitHub.
   Previous releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel.
@@ -64,6 +69,7 @@ Bazelisk currently understands the following formats for version labels:
 - The hash of a Git commit. Please note that Bazel binaries are only available for commits that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).
 
 Additionally, a few special version names are supported for our official releases only (these formats do not work when using a fork):
+
 - `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).
   Ideally this binary should be very close to Bazel-at-head.
 - `last_downstream_green` points to the most recent Bazel binary that builds and tests all [downstream projects](https://buildkite.com/bazel/bazel-at-head-plus-downstream) successfully.
@@ -98,6 +104,7 @@ an installer, then `tools/bazel` and `.bazelversion` are not checked. You could 
 require users update their bazel.
 
 [shell wrapper script]: https://github.com/bazelbuild/bazel/blob/master/scripts/packages/bazel.sh
+
 ## Other features
 
 The Go version of Bazelisk offers two new flags.
@@ -133,7 +140,6 @@ The Go version supports a `.bazeliskrc` file in the root directory of a workspac
 
 Example file content:
 
-
 ```shell
 USE_BAZEL_VERSION=0.19.0
 BAZELISK_GITHUB_TOKEN=abc
@@ -153,9 +159,9 @@ The following variables can be set:
 
 Configuration variables are evaluated with precedence order. The preferred values are derived in order from highest to lowest precedence as follows:
 
-* Variables defined in the environment
-* Variables defined in the workspace root `.bazeliskrc`
-* Variables defined in the user home `.bazeliskrc`
+- Variables defined in the environment
+- Variables defined in the workspace root `.bazeliskrc`
+- Variables defined in the user home `.bazeliskrc`
 
 ## Requirements
 
@@ -169,7 +175,9 @@ To install the Go version, type:
 ```shell
 go get github.com/bazelbuild/bazelisk
 ```
+
 With Go 1.17 or later, the recommended way to install it is:
+
 ```shell
 go install github.com/bazelbuild/bazelisk@latest
 ```
@@ -192,5 +200,6 @@ For more information, you may read about the [`GOPATH` environment variable](htt
 ## FAQ
 
 ### Where does Bazelisk store the downloaded versions of Bazel?
+
 It creates a directory called "bazelisk" inside your [user cache directory](https://golang.org/pkg/os/#UserCacheDir) and will store them there.
 Feel free to delete this directory at any time, as it can be regenerated automatically when required.

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -19,13 +19,14 @@ import (
 	"log"
 	"os"
 
+	"github.com/bazelbuild/bazelisk/configs"
 	"github.com/bazelbuild/bazelisk/core"
 	"github.com/bazelbuild/bazelisk/repositories"
 )
 
 func main() {
 	gcs := &repositories.GCSRepo{}
-	gitHub := repositories.CreateGitHubRepo(core.GetEnvOrConfig("BAZELISK_GITHUB_TOKEN"))
+	gitHub := repositories.CreateGitHubRepo(configs.GetEnvOrConfig("BAZELISK_GITHUB_TOKEN"))
 	// Fetch LTS releases, release candidates, rolling releases and Bazel-at-commits from GCS, forks from GitHub.
 	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
 

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+    ],
+    importpath = "github.com/bazelbuild/bazelisk/configs",
+    visibility = ["//visibility:public"],
+)

--- a/configs/config.go
+++ b/configs/config.go
@@ -1,0 +1,137 @@
+// Package configs provides a mechanism to read configuration values from the environment and from .bazeliskrc files.
+package configs
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	rcFileName = ".bazeliskrc"
+)
+
+var (
+	fileConfig     map[string]string
+	fileConfigOnce sync.Once
+)
+
+// GetEnvOrConfig reads a configuration value from the environment, but fall back to reading it from .bazeliskrc in the workspace root.
+func GetEnvOrConfig(name string) string {
+	if val := os.Getenv(name); val != "" {
+		return val
+	}
+
+	fileConfigOnce.Do(loadFileConfig)
+
+	return fileConfig[name]
+}
+
+// loadFileConfig locates available .bazeliskrc configuration files, parses them with a precedence order preference,
+// and updates a global configuration map with their contents. This routine should be executed exactly once.
+func loadFileConfig() {
+	var rcFilePaths []string
+
+	if userRC, err := locateUserConfigFile(); err == nil {
+		rcFilePaths = append(rcFilePaths, userRC)
+	}
+	if workspaceRC, err := locateWorkspaceConfigFile(); err == nil {
+		rcFilePaths = append(rcFilePaths, workspaceRC)
+	}
+
+	fileConfig = make(map[string]string)
+	for _, rcPath := range rcFilePaths {
+		config, err := parseFileConfig(rcPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for key, value := range config {
+			fileConfig[key] = value
+		}
+	}
+}
+
+// locateWorkspaceConfigFile locates a .bazeliskrc file in the current workspace root.
+func locateWorkspaceConfigFile() (string, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	workspaceRoot := FindWorkspaceRoot(workingDirectory)
+	if workspaceRoot == "" {
+		return "", err
+	}
+	return filepath.Join(workspaceRoot, rcFileName), nil
+}
+
+// locateUserConfigFile locates a .bazeliskrc file in the user's home directory.
+func locateUserConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, rcFileName), nil
+}
+
+// parseFileConfig parses a .bazeliskrc file as a map of key-value configuration values.
+func parseFileConfig(rcFilePath string) (map[string]string, error) {
+	config := make(map[string]string)
+
+	contents, err := ioutil.ReadFile(rcFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Non-critical error.
+			return config, nil
+		}
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(contents), "\n") {
+		if strings.HasPrefix(line, "#") {
+			// comments
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		config[key] = strings.TrimSpace(parts[1])
+	}
+
+	return config, nil
+}
+
+// isValidWorkspace returns true iff the supplied path is the workspace root, defined by the presence of
+// a file named WORKSPACE or WORKSPACE.bazel
+// see https://github.com/bazelbuild/bazel/blob/8346ea4cfdd9fbd170d51a528fee26f912dad2d5/src/main/cpp/workspace_layout.cc#L37
+func isValidWorkspace(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return !info.IsDir()
+}
+
+// FindWorkspaceRoot returns root directory where the WORKSPACE file is located at.
+func FindWorkspaceRoot(root string) string {
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE")) {
+		return root
+	}
+
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE.bazel")) {
+		return root
+	}
+
+	parentDirectory := filepath.Dir(root)
+	if parentDirectory == root {
+		return ""
+	}
+
+	return FindWorkspaceRoot(parentDirectory)
+}

--- a/core/BUILD
+++ b/core/BUILD
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
     deps = [
+        "//configs:go_default_library",
         "//httputil:go_default_library",
         "//platforms:go_default_library",
         "//versions:go_default_library",

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/platforms",
     visibility = ["//visibility:public"],
     deps = [
+        "//configs:go_default_library",
         "//versions:go_default_library",
         "@com_github_hashicorp_go_version//:go_default_library",
     ],

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"runtime"
 
+	"github.com/bazelbuild/bazelisk/configs"
 	"github.com/bazelbuild/bazelisk/versions"
 	semver "github.com/hashicorp/go-version"
 )
@@ -83,7 +84,11 @@ func DetermineBazelFilename(version string, includeSuffix bool) (string, error) 
 		filenameSuffix = DetermineExecutableFilenameSuffix()
 	}
 
-	return fmt.Sprintf("bazel-%s-%s-%s%s", version, osName, machineName, filenameSuffix), nil
+	bazelFlavor := "bazel"
+	if configs.GetEnvOrConfig("BAZELISK_NOJDK") == "1" {
+		bazelFlavor = "bazel_nojdk"
+	}
+	return fmt.Sprintf("%s-%s-%s-%s%s", bazelFlavor, version, osName, machineName, filenameSuffix), nil
 }
 
 // DarwinFallback Darwin arm64 was supported since 4.1.0, before 4.1.0, fall back to x86_64


### PR DESCRIPTION
Support `BAZELISK_NOJDK` in Bazelisk Go.

Note that Bazel didn't provide NOJDK version for Linux arm64 version. This problem should be fixed in Bazel repo.
