### PR TITLE
bazelisk.py notices WORKSPACE.bazel as a workspace_root

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -97,6 +97,8 @@ def find_workspace_root(root=None):
         root = os.getcwd()
     if os.path.exists(os.path.join(root, "WORKSPACE")):
         return root
+    if os.path.exists(os.path.join(root, "WORKSPACE.bazel")):
+        return root
     new_root = os.path.dirname(root)
     return find_workspace_root(new_root) if new_root != root else None
 


### PR DESCRIPTION
> Bazel also supports WORKSPACE.bazel file as an alias of WORKSPACE file. If both files exist, WORKSPACE.bazel is used.

-- https://bazel.build/concepts/build-ref#workspace

The Go version already has this:

https://github.com/bazelbuild/bazelisk/blob/v1.16.0/core/core.go#L301