### PR TITLE
--bisect: ignore merge commit

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -734,8 +734,13 @@ func cleanIfNeeded(bazelPath string, startupOptions []string) {
 	}
 }
 
+type ParentCommit struct {
+	SHA string `json:"sha"`
+}
+
 type Commit struct {
 	SHA string `json:"sha"`
+	PARENTS []ParentCommit `json:"parents"`
 }
 
 type CompareResponse struct {
@@ -803,7 +808,10 @@ func getBazelCommitsBetween(goodCommit string, badCommit string) ([]string, erro
 		}
 
 		for _, commit := range compareResponse.Commits {
-			commitList = append(commitList, commit.SHA)
+			// If it has only one parent commit, add it to the list, otherwise it's a merge commit and we ignore it
+			if len(commit.PARENTS) == 1 {
+				commitList = append(commitList, commit.SHA)
+			}
 		}
 
 		// Check if there are more commits to fetch


### PR DESCRIPTION
We accidentally pushed [merge commits](https://github.com/bazelbuild/bazel/commits?author=Pavank1992) to master (during merging third party changes), this may break bisect since the publish Bazel binaries pipeline doesn't build at merge commits, therefore we skip those merge commits for bisecting.