### PR TITLE
Extract config fetching into its own package

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -25,11 +25,12 @@ import (
 
 func main() {
 	gcs := &repositories.GCSRepo{}
-	gitHub := repositories.CreateGitHubRepo(core.GetEnvOrConfig("BAZELISK_GITHUB_TOKEN"))
+	config := core.MakeDefaultConfig()
+	gitHub := repositories.CreateGitHubRepo(config.Get("BAZELISK_GITHUB_TOKEN"))
 	// Fetch LTS releases, release candidates, rolling releases and Bazel-at-commits from GCS, forks from GitHub.
 	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
 
-	exitCode, err := core.RunBazelisk(os.Args[1:], repos)
+	exitCode, err := core.RunBazeliskWithArgsFuncAndConfig(func(string) []string { return os.Args[1:] }, repos, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/bazelbuild/bazelisk/config",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ws:go_default_library",
+        "@com_github_mitchellh_go_homedir//:go_default_library",
+    ],
+)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/bazelisk/ws"
+)
+
+const rcFileName = ".bazeliskrc"
+
+// Config allows getting Bazelisk configuration values.
+type Config interface {
+	Get(name string) string
+}
+
+// FromEnv returns a Config which gets config values from environment variables.
+func FromEnv() Config {
+	return &fromEnv{}
+}
+
+type fromEnv struct{}
+
+func (c *fromEnv) Get(name string) string {
+	return os.Getenv(name)
+}
+
+// FromFile returns a Config which gets config values from a Bazelisk config file.
+func FromFile(path string) (Config, error) {
+	values, err := parseFileConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	return &static{
+		values: values,
+	}, nil
+}
+
+type static struct {
+	values map[string]string
+}
+
+func (c *static) Get(name string) string {
+	return c.values[name]
+}
+
+// parseFileConfig parses a .bazeliskrc file as a map of key-value configuration values.
+func parseFileConfig(rcFilePath string) (map[string]string, error) {
+	config := make(map[string]string)
+
+	contents, err := ioutil.ReadFile(rcFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Non-critical error.
+			return config, nil
+		}
+		return nil, err
+	}
+
+	for _, line := range strings.Split(string(contents), "\n") {
+		if strings.HasPrefix(line, "#") {
+			// comments
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		config[key] = strings.TrimSpace(parts[1])
+	}
+
+	return config, nil
+}
+
+// LocateUserConfigFile locates a .bazeliskrc file in the user's home directory.
+func LocateUserConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, rcFileName), nil
+}
+
+// LocateWorkspaceConfigFile locates a .bazeliskrc file in the current workspace root.
+func LocateWorkspaceConfigFile() (string, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	workspaceRoot := ws.FindWorkspaceRoot(workingDirectory)
+	if workspaceRoot == "" {
+		return "", err
+	}
+	return filepath.Join(workspaceRoot, rcFileName), nil
+}
+
+// Layered returns a Config which gets config values from the first of a series of other Config values which sets the config.
+func Layered(configs ...Config) Config {
+	return &layered{
+		configs: configs,
+	}
+}
+
+type layered struct {
+	configs []Config
+}
+
+func (c *layered) Get(name string) string {
+	for _, config := range c.configs {
+		if value := config.Get(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// Null returns a Config with no config values.
+func Null() Config {
+	return &static{}
+}
+
+// Static returns a Config with static values.
+func Static(values map[string]string) Config {
+	return &static{
+		values: values,
+	}
+}

--- a/core/BUILD
+++ b/core/BUILD
@@ -10,9 +10,11 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
     deps = [
+        "//config:go_default_library",
         "//httputil:go_default_library",
         "//platforms:go_default_library",
         "//versions:go_default_library",
+        "//ws:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
     ],
 )
@@ -24,4 +26,7 @@ go_test(
         "repositories_test.go",
     ],
     embed = [":go_default_library"],
+    deps = [
+        "//config:go_default_library",
+    ],
 )

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/bazelbuild/bazelisk/config"
 )
 
 func TestMaybeDelegateToNoWrapper(t *testing.T) {
@@ -16,11 +18,11 @@ func TestMaybeDelegateToNoWrapper(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := "bazel_real"
 
 	if entrypoint != expected {
@@ -35,21 +37,21 @@ func TestMaybeDelegateToNoNonExecutableWrapper(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		return
 	}
-	
+
 	tmpDir, err := ioutil.TempDir("", "TestMaybeDelegateToNoNonExecutableWrapper")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir | 0700)
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel"), []byte(""), 0600)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := "bazel_real"
 
 	if entrypoint != expected {
@@ -71,14 +73,14 @@ func TestMaybeDelegateToStandardWrapper(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir | 0700)
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel"), []byte(""), 0700)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := filepath.Join(tmpDir, "tools", "bazel")
 
 	if entrypoint != expected {
@@ -93,14 +95,14 @@ func TestMaybeDelegateToPowershellWrapper(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir | 0700)
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel.ps1"), []byte(""), 0700)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := filepath.Join(tmpDir, "tools", "bazel.ps1")
 
 	// Only windows platforms use powershell wrappers
@@ -120,14 +122,14 @@ func TestMaybeDelegateToBatchWrapper(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir | 0700)
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel.bat"), []byte(""), 0700)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := filepath.Join(tmpDir, "tools", "bazel.bat")
 
 	// Only windows platforms use batch wrappers
@@ -147,15 +149,15 @@ func TestMaybeDelegateToPowershellOverBatchWrapper(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	os.MkdirAll(tmpDir, os.ModeDir | 0700)
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
 	ioutil.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
 
-	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir | 0700)
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel.ps1"), []byte(""), 0700)
 	ioutil.WriteFile(filepath.Join(tmpDir, "tools", "bazel.bat"), []byte(""), 0700)
 
-	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, true)
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := filepath.Join(tmpDir, "tools", "bazel.ps1")
 
 	// Only windows platforms use powershell or batch wrappers

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bazelbuild/bazelisk/config"
 	"github.com/bazelbuild/bazelisk/httputil"
 	"github.com/bazelbuild/bazelisk/platforms"
 	"github.com/bazelbuild/bazelisk/versions"
@@ -235,7 +236,7 @@ func (r *Repositories) DownloadFromBaseURL(baseURL, version, destDir, destFile s
 	return httputil.DownloadBinary(url, destDir, destFile)
 }
 
-func BuildURLFromFormat(formatURL, version string) (string, error) {
+func BuildURLFromFormat(config config.Config, formatURL, version string) (string, error) {
 	osName, err := platforms.DetermineOperatingSystem()
 	if err != nil {
 		return "", err
@@ -261,7 +262,7 @@ func BuildURLFromFormat(formatURL, version string) (string, error) {
 			case 'e':
 				b.WriteString(platforms.DetermineExecutableFilenameSuffix())
 			case 'h':
-				b.WriteString(GetEnvOrConfig("BAZELISK_VERIFY_SHA256"))
+				b.WriteString(config.Get("BAZELISK_VERIFY_SHA256"))
 			case 'm':
 				b.WriteString(machineName)
 			case 'o':
@@ -281,12 +282,12 @@ func BuildURLFromFormat(formatURL, version string) (string, error) {
 }
 
 // DownloadFromFormatURL can download Bazel binaries from a specific URL while ignoring the predefined repositories.
-func (r *Repositories) DownloadFromFormatURL(formatURL, version, destDir, destFile string) (string, error) {
+func (r *Repositories) DownloadFromFormatURL(config config.Config, formatURL, version, destDir, destFile string) (string, error) {
 	if formatURL == "" {
 		return "", fmt.Errorf("%s is not set", FormatURLEnv)
 	}
 
-	url, err := BuildURLFromFormat(formatURL, version)
+	url, err := BuildURLFromFormat(config, formatURL, version)
 	if err != nil {
 		return "", err
 	}

--- a/core/repositories_test.go
+++ b/core/repositories_test.go
@@ -3,9 +3,9 @@ package core
 import (
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
+	"github.com/bazelbuild/bazelisk/config"
 	"github.com/bazelbuild/bazelisk/platforms"
 )
 
@@ -24,18 +24,10 @@ func TestBuildURLFromFormat(t *testing.T) {
 
 	suffix := platforms.DetermineExecutableFilenameSuffix()
 
-	previousSha256, hadSha256 := os.LookupEnv("BAZELISK_VERIFY_SHA256")
 	sha256 := "SomeSha256ValueThatIsIrrelevant"
-	if err := os.Setenv("BAZELISK_VERIFY_SHA256", sha256); err != nil {
-		t.Fatalf("Failed to set BAZELISK_VERIFY_SHA256")
-	}
-	defer func() {
-		if hadSha256 {
-			os.Setenv("BAZELISK_VERIFY_SHA256", previousSha256)
-		} else {
-			os.Unsetenv("BAZELISK_VERIFY_SHA256")
-		}
-	}()
+	config := config.Static(map[string]string{
+		"BAZELISK_VERIFY_SHA256": sha256,
+	})
 
 	type test struct {
 		format  string
@@ -65,7 +57,7 @@ func TestBuildURLFromFormat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := BuildURLFromFormat(tc.format, version)
+		got, err := BuildURLFromFormat(config, tc.format, version)
 		if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", tc.wantErr) {
 			if got != "" {
 				t.Errorf("format '%s': got non-empty '%s' on error", tc.format, got)

--- a/ws/BUILD
+++ b/ws/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ws.go"],
+    importpath = "github.com/bazelbuild/bazelisk/ws",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_mitchellh_go_homedir//:go_default_library",
+    ],
+)

--- a/ws/ws.go
+++ b/ws/ws.go
@@ -1,0 +1,36 @@
+package ws
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FindWorkspaceRoot returns the root directory of the Bazel workspace in which the passed root exists, if any.
+func FindWorkspaceRoot(root string) string {
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE")) {
+		return root
+	}
+
+	if isValidWorkspace(filepath.Join(root, "WORKSPACE.bazel")) {
+		return root
+	}
+
+	parentDirectory := filepath.Dir(root)
+	if parentDirectory == root {
+		return ""
+	}
+
+	return FindWorkspaceRoot(parentDirectory)
+}
+
+// isValidWorkspace returns true iff the supplied path is the workspace root, defined by the presence of
+// a file named WORKSPACE or WORKSPACE.bazel
+// see https://github.com/bazelbuild/bazel/blob/8346ea4cfdd9fbd170d51a528fee26f912dad2d5/src/main/cpp/workspace_layout.cc#L37
+func isValidWorkspace(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return !info.IsDir()
+}


### PR DESCRIPTION
My goal here is to be able to pass my own config implementation when calling RunBazelisk from code without setting environment variables, because they cause repository rule cache invalidations.

As a side-effect, it helps towards the TODO in core.go to split functionality into packages.