### PR TITLE
Remove duplicated test

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -12,12 +12,6 @@ go_library(
 )
 
 go_test(
-    name = "platforms_test",
-    srcs = ["platforms_test.go"],
-    embed = [":go_default_library"],
-)
-
-go_test(
     name = "go_default_test",
     srcs = ["platforms_test.go"],
     embed = [":go_default_library"],


### PR DESCRIPTION
Duplicated `go_tests` can result in compilation actions failing due to https://github.com/bazelbuild/rules_go/issues/3558.