### PR TITLE
go_netrc: switch back to gazelle style import

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,10 +44,9 @@ go_repository(
 
 go_repository(
     name = "com_github_bgentry_go_netrc",
-    importpath = "github.com/bgentry/go-netrc/netrc",
-    urls = ["https://github.com/bgentry/go-netrc/archive/9fd32a8.zip"],
-    type = "zip",
-    strip_prefix = "go-netrc-9fd32a8b3d3d3f9d43c341bfe098430e07609480/netrc",
+    importpath = "github.com/bgentry/go-netrc",
+    sum = "h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=",
+    version = "v0.0.0-20140422174119-9fd32a8b3d3d",
 )
 
 go_rules_dependencies()

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -13,7 +13,7 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/httputil",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_bgentry_go_netrc//:go_default_library",
+        "@com_github_bgentry_go_netrc//netrc:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
     ],
 )


### PR DESCRIPTION
This enables other projects to depend on bazelisk using a gazelle
generated go_repository for com_github_bgentry_go_netrc, instead of
having to use the archive strip_prefix go_repository that Bazelisk
handcrafted.
