### PR TITLE
fix(npm): replace version placeholder with stamp value

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -154,6 +154,7 @@ go_binary(
 pkg_npm(
     name = "npm_package",
     package_name = "@bazel/bazelisk",
+    substitutions = {"0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}"},
     srcs = [
         "LICENSE",
         "README.md",


### PR DESCRIPTION
My guess is this was broken by https://github.com/bazelbuild/bazelisk/pull/348

See docs: https://github.com/bazelbuild/rules_nodejs/blob/5.5.3/docs/stamping.md#substitutions-attribute