### PR TITLE
Teach bazelisk.py about .bazeliskrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can control the user agent that Bazelisk sends in all HTTP requests by setti
 
 # .bazeliskrc configuration file
 
-The Go version supports a `.bazeliskrc` file in the root directory of a workspace and the user home directory. This file allows users to set environment variables persistently.
+A `.bazeliskrc` file in the root directory of a workspace or the user home directory allows users to set environment variables persistently.
 
 Example file content:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can control the user agent that Bazelisk sends in all HTTP requests by setti
 
 # .bazeliskrc configuration file
 
-A `.bazeliskrc` file in the root directory of a workspace or the user home directory allows users to set environment variables persistently.
+A `.bazeliskrc` file in the root directory of a workspace or the user home directory allows users to set environment variables persistently. (The Python implementation of Bazelisk doesn't check the user home directory yet, only the workspace directory.)
 
 Example file content:
 

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -68,6 +68,31 @@ BAZEL_REAL = "BAZEL_REAL"
 BAZEL_UPSTREAM = "bazelbuild"
 
 
+def get_env_or_config(name, default=None):
+    """Reads a configuration value from the environment, but falls back to
+    reading it from .bazeliskrc in the workspace root."""
+    if name in os.environ:
+        return os.environ[name]
+    env_files = []
+    root = find_workspace_root()
+    if root:
+        env_files.append(os.path.join(root, ".bazeliskrc"))
+    for env_file in env_files:
+        try:
+            with open(env_file, "r") as f:
+                rcdata = f.read()
+        except Exception:
+            continue
+        for line in rcdata.splitlines():
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            some_name, some_value = line.split("=", 1)
+            if some_name == name:
+                return some_value
+    return default
+
+
 def decide_which_bazel_version_to_use():
     # Check in this order:
     # - env var "USE_BAZEL_VERSION" is set to a specific version.
@@ -79,8 +104,9 @@ def decide_which_bazel_version_to_use():
     # - workspace_root/.bazelversion exists -> read contents, that version.
     # - workspace_root/WORKSPACE contains a version -> that version. (TODO)
     # - fallback: latest release
-    if "USE_BAZEL_VERSION" in os.environ:
-        return os.environ["USE_BAZEL_VERSION"]
+    use_bazel_version = get_env_or_config("USE_BAZEL_VERSION")
+    if use_bazel_version is not None:
+        return use_bazel_version
 
     workspace_root = find_workspace_root()
     if workspace_root:
@@ -229,7 +255,7 @@ def determine_bazel_filename(version):
 
     filename_suffix = determine_executable_filename_suffix()
     bazel_flavor = "bazel"
-    if os.environ.get("BAZELISK_NOJDK", "0") != "0":
+    if get_env_or_config("BAZELISK_NOJDK", "0") != "0":
         bazel_flavor = "bazel_nojdk"
     return "{}-{}-{}-{}{}".format(bazel_flavor, version, operating_system, machine, filename_suffix)
 
@@ -280,8 +306,9 @@ def determine_url(version, is_commit, bazel_filename):
     # Example: '0.19.1' -> ('0.19.1', None), '0.20.0rc1' -> ('0.20.0', 'rc1')
     (version, rc) = re.match(r"(\d*\.\d*(?:\.\d*)?)(rc\d+)?", version).groups()
 
-    if "BAZELISK_BASE_URL" in os.environ:
-        return "{}/{}/{}".format(os.environ["BAZELISK_BASE_URL"], version, bazel_filename)
+    bazelisk_base_url = get_env_or_config("BAZELISK_BASE_URL")
+    if bazelisk_base_url is not None:
+        return "{}/{}/{}".format(bazelisk_base_url, version, bazel_filename)
     else:
         return "https://releases.bazel.build/{}/{}/{}".format(
             version, rc if rc else "release", bazel_filename
@@ -345,7 +372,7 @@ def download_bazel_into_directory(version, is_commit, directory):
 def download(url, destination_path):
     sys.stderr.write("Downloading {}...\n".format(url))
     request = Request(url)
-    if "BAZELISK_BASE_URL" in os.environ:
+    if get_env_or_config("BAZELISK_BASE_URL") is not None:
         parts = urlparse(url)
         creds = None
         try:
@@ -360,7 +387,7 @@ def download(url, destination_path):
 
 
 def get_bazelisk_directory():
-    bazelisk_home = os.environ.get("BAZELISK_HOME")
+    bazelisk_home = get_env_or_config("BAZELISK_HOME")
     if bazelisk_home is not None:
         return bazelisk_home
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -508,6 +508,14 @@ echo "# test_bazel_version_from_environment"
 test_bazel_version_from_environment
 echo
 
+echo "# test_bazel_version_prefer_environment_to_bazeliskrc"
+test_bazel_version_prefer_environment_to_bazeliskrc
+echo
+
+echo "# test_bazel_version_from_workspace_bazeliskrc"
+test_bazel_version_from_workspace_bazeliskrc
+echo
+
 echo "# test_bazel_version_from_file"
 test_bazel_version_from_file
 echo
@@ -543,14 +551,6 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
 
   echo "# test_bazel_version_from_base_url"
   test_bazel_version_from_base_url
-  echo
-
-  echo "# test_bazel_version_prefer_environment_to_bazeliskrc"
-  test_bazel_version_prefer_environment_to_bazeliskrc
-  echo
-
-  echo "# test_bazel_version_from_workspace_bazeliskrc"
-  test_bazel_version_from_workspace_bazeliskrc
   echo
 
   echo "# test_bazel_version_from_user_home_bazeliskrc"


### PR DESCRIPTION
This allows for suggesting (but not requiring) a bazel version using the bazeliskrc dotfile.