### PR TITLE
Support `MODULE.bazel` and `REPO.bazel`

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -95,10 +95,10 @@ def decide_which_bazel_version_to_use():
 def find_workspace_root(root=None):
     if root is None:
         root = os.getcwd()
-    if os.path.exists(os.path.join(root, "WORKSPACE")):
-        return root
-    if os.path.exists(os.path.join(root, "WORKSPACE.bazel")):
-        return root
+    for boundary in ["MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"]:
+        path = os.path.join(root, boundary)
+        if os.path.exists(path) and not os.path.isdir(path):
+            return root
     new_root = os.path.dirname(root)
     return find_workspace_root(new_root) if new_root != root else None
 

--- a/ws/ws.go
+++ b/ws/ws.go
@@ -7,12 +7,10 @@ import (
 
 // FindWorkspaceRoot returns the root directory of the Bazel workspace in which the passed root exists, if any.
 func FindWorkspaceRoot(root string) string {
-	if isValidWorkspace(filepath.Join(root, "WORKSPACE")) {
-		return root
-	}
-
-	if isValidWorkspace(filepath.Join(root, "WORKSPACE.bazel")) {
-		return root
+	for _, boundary := range [...]string{"MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"} {
+		if isValidWorkspace(filepath.Join(root, boundary)) {
+			return root
+		}
 	}
 
 	parentDirectory := filepath.Dir(root)
@@ -23,9 +21,9 @@ func FindWorkspaceRoot(root string) string {
 	return FindWorkspaceRoot(parentDirectory)
 }
 
-// isValidWorkspace returns true iff the supplied path is the workspace root, defined by the presence of
-// a file named WORKSPACE or WORKSPACE.bazel
-// see https://github.com/bazelbuild/bazel/blob/8346ea4cfdd9fbd170d51a528fee26f912dad2d5/src/main/cpp/workspace_layout.cc#L37
+// isValidWorkspace returns true if the supplied path is the workspace root, defined by the presence of
+// a file named MODULE.bazel, REPO.bazel, WORKSPACE.bazel, or WORKSPACE
+// see https://github.com/bazelbuild/bazel/blob/6.3.0/src/main/cpp/workspace_layout.cc#L34
 func isValidWorkspace(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
As of Bazel 6.3.0, `MODULE.bazel` and `REPO.bazel` are also considered workspace boundaries. Bazelisk now searches for these in the same order Bazel does.

Fixes #502