### PR TITLE
README.md: Fix .bazelversion location

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The documentation below describes the newer Go version only.
 It uses a simple algorithm:
 - If the environment variable `USE_BAZEL_VERSION` is set, it will use the version specified in the value.
 - Otherwise, if a `.bazeliskrc` file exists in the workspace root and contains the `USE_BAZEL_VERSION` variable, this version will be used.
-- Otherwise, if a `.bazelversion` file exists in the current directory or recursively any parent directory, it will read the file and use the version specified in it.
+- Otherwise, if a `.bazelversion` file exists in the workspace root, it will read the file and use the version specified in it.
 - Otherwise, if the environment variable `USE_BAZEL_FALLBACK_VERSION` is set to one of the following formats:
   - If set to a value starting with `error:`, it will report an error and version detection will fail.
   - If set to a value starting with `warn:`, it will report a warning and use the version specified after the prefix.


### PR DESCRIPTION
The Python and Go implementations both look for `.bazelversion` only in the workspace root.