### PR TITLE
httputil: Avoid displaying percentage in download progress when response `Content-Length` is not defined

### DIFF
--- a/httputil/progress/progress.go
+++ b/httputil/progress/progress.go
@@ -85,11 +85,19 @@ func (p *progress) Write(buf []byte) (int, error) {
 
 // Writes the current download progress to stdout.
 func (p *progress) ShowProgress() {
-	message := fmt.Sprintf("%s: %s out of %s (%s)",
-		p.header,
-		formatMb(p.current),
-		formatMb(p.total),
-		formatPercentage(p.current, p.total))
+	var message string
+
+	if p.total > 0 {
+		message = fmt.Sprintf("%s: %s out of %s (%s)",
+			p.header,
+			formatMb(p.current),
+			formatMb(p.total),
+			formatPercentage(p.current, p.total))
+	} else {
+		message = fmt.Sprintf("%s: %s",
+			p.header,
+			formatMb(p.current))
+	}
 
 	if message == p.lastMessage {
 		return


### PR DESCRIPTION
## Summary

`Content-Length` may not necessarily be defined in the HTTP response headers for the Bazel binary blob. For example, this may be the case for mirrors or proxies that transmit the body using chunked transfer encoding. In such cases, the "total" is not meaningful, which breaks the percentage text in the new download progress indicator.

This patch updates the progress message text to handle such cases.

Extends: #511

## Symptom

```bash
$ bazelisk --help
2024/01/28 06:35:59 Downloading https://artifacts.internal.example.com/bazel/6.5.0/bazel-6.5.0-linux-x86_64...
Downloading: 8 MB out of 0 MB (-881459200%)
```

## Verification

Downloading from a proprietary mirror that elides `Content-Length`:

```bash
$ bazelisk-linux_amd64 --help
2024/01/28 06:27:19 Downloading https://artifacts.internal.example.com/bazel/6.5.0/bazel-6.5.0-linux-x86_64...
Downloading: 52 MB                     
Starting local Bazel server and connecting to it...
                                                           [bazel release 6.5.0]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  mod                 Queries the Bzlmod external dependency graph
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.

Getting more help:
  bazel help <command>
                   Prints help and options for <command>.
  bazel help startup_options
                   Options for the JVM hosting bazel.
  bazel help target-syntax
                   Explains the syntax for specifying targets.
  bazel help info-keys
                   Displays a list of keys used by the info command.
```

Downloading from the public repository:

```bash
$ bazelisk-linux_amd64 --help
2024/01/28 06:30:07 Downloading https://releases.bazel.build/6.5.0/release/bazel-6.5.0-linux-x86_64...
Downloading: 52 MB out of 52 MB (100%) 
                                                           [bazel release 6.5.0]
Usage: bazel <command> <options> ...

Available commands:
  analyze-profile     Analyzes build profile data.
  aquery              Analyzes the given targets and queries the action graph.
  build               Builds the specified targets.
  canonicalize-flags  Canonicalizes a list of bazel options.
  clean               Removes output files and optionally stops the server.
  coverage            Generates code coverage report for specified test targets.
  cquery              Loads, analyzes, and queries the specified targets w/ configurations.
  dump                Dumps the internal state of the bazel server process.
  fetch               Fetches external repositories that are prerequisites to the targets.
  help                Prints help for commands, or the index.
  info                Displays runtime info about the bazel server.
  license             Prints the license of this software.
  mobile-install      Installs targets to mobile devices.
  mod                 Queries the Bzlmod external dependency graph
  print_action        Prints the command line args for compiling a file.
  query               Executes a dependency graph query.
  run                 Runs the specified target.
  shutdown            Stops the bazel server.
  sync                Syncs all repositories specified in the workspace file
  test                Builds and runs the specified test targets.
  version             Prints version information for bazel.

Getting more help:
  bazel help <command>
                   Prints help and options for <command>.
  bazel help startup_options
                   Options for the JVM hosting bazel.
  bazel help target-syntax
                   Explains the syntax for specifying targets.
  bazel help info-keys
                   Displays a list of keys used by the info command.
```