### PR TITLE
Allow overriding tools/bazel path with BAZELISK_WRAPPER_DIRECTORY

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -33,10 +33,11 @@ import (
 )
 
 const (
-	bazelReal      = "BAZEL_REAL"
-	skipWrapperEnv = "BAZELISK_SKIP_WRAPPER"
-	wrapperPath    = "./tools/bazel"
-	maxDirLength   = 255
+	bazelReal               = "BAZEL_REAL"
+	skipWrapperEnv          = "BAZELISK_SKIP_WRAPPER"
+	defaultWrapperDirectory = "./tools"
+	defaultWrapperName      = "bazel"
+	maxDirLength            = 255
 )
 
 var (
@@ -494,6 +495,13 @@ func linkLocalBazel(baseDirectory string, bazelPath string) (string, error) {
 func maybeDelegateToWrapperFromDir(bazel string, wd string, config config.Config) string {
 	if config.Get(skipWrapperEnv) != "" {
 		return bazel
+	}
+
+	wrapperPath := config.Get("BAZELISK_WRAPPER_DIRECTORY")
+	if wrapperPath == "" {
+		wrapperPath = filepath.Join(defaultWrapperDirectory, defaultWrapperName)
+	} else {
+		wrapperPath = filepath.Join(wrapperPath, defaultWrapperName)
 	}
 
 	root := ws.FindWorkspaceRoot(wd)


### PR DESCRIPTION
In some projects the tools/bazel path isn't practical. This allows users to override this path with the BAZELISK_WRAPPER_DIRECTORY env var / .bazeliskrc config option. This allows overriding the root
directory that the `bazel` wrapper executable should be found in. This was chosen over the file itself
in order to continue supporting recursive `bazel` invocations.