### PR TITLE
Remove go_default_library & go_default_test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,43 +39,43 @@ sh_test(
 )
 
 go_library(
-    name = "go_default_library",
+    name = "bazelisk_lib",
     srcs = ["bazelisk.go"],
     importpath = "github.com/bazelbuild/bazelisk",
     visibility = ["//visibility:private"],
     deps = [
-        "//core:go_default_library",
-        "//repositories:go_default_library",
+        "//core",
+        "//repositories",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "bazelisk_version_test",
     srcs = ["bazelisk_version_test.go"],
     data = [
         "sample-issues-migration.json",
     ],
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     importpath = "github.com/bazelbuild/bazelisk",
     deps = [
-        "//config:go_default_library",
-        "//core:go_default_library",
-        "//httputil:go_default_library",
-        "//repositories:go_default_library",
-        "//versions:go_default_library",
+        "//config",
+        "//core",
+        "//httputil",
+        "//repositories",
+        "//versions",
     ],
 )
 
 go_binary(
     name = "bazelisk",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_binary(
     name = "bazelisk-darwin-amd64",
     out = "bazelisk-darwin_amd64",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -89,7 +89,7 @@ go_binary(
 go_binary(
     name = "bazelisk-darwin-arm64",
     out = "bazelisk-darwin_arm64",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -117,7 +117,7 @@ genrule(
 go_binary(
     name = "bazelisk-linux-amd64",
     out = "bazelisk-linux_amd64",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -131,7 +131,7 @@ go_binary(
 go_binary(
     name = "bazelisk-linux-arm64",
     out = "bazelisk-linux_arm64",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     gc_linkopts = [
         "-s",
         "-w",
@@ -145,7 +145,7 @@ go_binary(
 go_binary(
     name = "bazelisk-windows-amd64",
     out = "bazelisk-windows_amd64.exe",
-    embed = [":go_default_library"],
+    embed = [":bazelisk_lib"],
     goarch = "amd64",
     goos = "windows",
     pure = "on",

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,12 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "config",
     srcs = ["config.go"],
     importpath = "github.com/bazelbuild/bazelisk/config",
     visibility = ["//visibility:public"],
     deps = [
-        "//ws:go_default_library",
+        "//ws",
         "@com_github_mitchellh_go_homedir//:go_default_library",
     ],
 )

--- a/core/BUILD
+++ b/core/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "core",
     srcs = [
         "core.go",
         "repositories.go",
@@ -10,23 +10,23 @@ go_library(
     visibility = ["//visibility:public"],
     x_defs = {"BazeliskVersion": "{STABLE_VERSION}"},
     deps = [
-        "//config:go_default_library",
-        "//httputil:go_default_library",
-        "//platforms:go_default_library",
-        "//versions:go_default_library",
-        "//ws:go_default_library",
+        "//config",
+        "//httputil",
+        "//platforms",
+        "//versions",
+        "//ws",
         "@com_github_mitchellh_go_homedir//:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "core_test",
     srcs = [
         "core_test.go",
         "repositories_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":core"],
     deps = [
-        "//config:go_default_library",
+        "//config",
     ],
 )

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 gazelle(name = "gazelle")
 
 go_library(
-    name = "go_default_library",
+    name = "httputil",
     srcs = [
         "fake.go",
         "httputil.go",
@@ -13,17 +13,17 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/httputil",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//httputil/progress:go_default_library",
+        "//config",
+        "//httputil/progress",
         "@com_github_bgentry_go_netrc//netrc:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "httputil_test",
     srcs = [
         "httputil_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":httputil"],
 )

--- a/httputil/progress/BUILD
+++ b/httputil/progress/BUILD
@@ -5,22 +5,22 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 gazelle(name = "gazelle")
 
 go_library(
-    name = "go_default_library",
+    name = "progress",
     srcs = [
         "progress.go",
     ],
     importpath = "github.com/bazelbuild/bazelisk/httputil/progress",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
+        "//config",
         "@org_golang_x_term//:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "progress_test",
     srcs = [
         "progress_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":progress"],
 )

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,19 +1,19 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "platforms",
     srcs = ["platforms.go"],
     importpath = "github.com/bazelbuild/bazelisk/platforms",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//versions:go_default_library",
+        "//config",
+        "//versions",
         "@com_github_hashicorp_go_version//:go_default_library",
     ],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "platforms_test",
     srcs = ["platforms_test.go"],
-    embed = [":go_default_library"],
+    embed = [":platforms"],
 )

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "repositories",
     srcs = [
         "gcs.go",
         "github.go",
@@ -9,10 +9,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/repositories",
     visibility = ["//visibility:public"],
     deps = [
-        "//config:go_default_library",
-        "//core:go_default_library",
-        "//httputil:go_default_library",
-        "//platforms:go_default_library",
-        "//versions:go_default_library",
+        "//config",
+        "//core",
+        "//httputil",
+        "//platforms",
+        "//versions",
     ],
 )

--- a/versions/BUILD
+++ b/versions/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "versions",
     srcs = ["versions.go"],
     importpath = "github.com/bazelbuild/bazelisk/versions",
     visibility = ["//visibility:public"],

--- a/ws/BUILD
+++ b/ws/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "go_default_library",
+    name = "ws",
     srcs = ["ws.go"],
     importpath = "github.com/bazelbuild/bazelisk/ws",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Apparently gazelle no longer needs these specific names, and they make importing code into our internal repository much harder.