### PR TITLE
Upgrade: Go SDK to 1.22.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,10 +1,9 @@
 module(name = "bazelisk", version="")
 
-bazel_dep(name = "gazelle", version = "0.32.0", repo_name = "bazel_gazelle")
-bazel_dep(name = "platforms", version = "0.0.7")
-bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.38.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_go", version = "0.49.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "aspect_rules_js", version = "1.39.1")
-# -- bazel_dep definitions -- #
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.22.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "aspect_rules_js", version = "1.39.1")
 # -- bazel_dep definitions -- #
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.20.5")
+go_sdk.download(version = "1.22.5")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/README.md
+++ b/README.md
@@ -202,15 +202,10 @@ Configuration variables are evaluated with precedence order. The preferred value
 
 For ease of use, the Python version of Bazelisk is written to work with Python 2.7 and 3.x and only uses modules provided by the standard library.
 
-The Go version can be compiled to run natively on Linux, macOS and Windows.
-You need at least Go 1.11 to build Bazelisk, otherwise you'll run into errors like `undefined: os.UserCacheDir`.
+The Go version can be compiled to run natively on Linux, macOS and Windows. 
 
-To install the Go version, type:
+To install it, run:
 
-```shell
-go get github.com/bazelbuild/bazelisk
-```
-With Go 1.17 or later, the recommended way to install it is:
 ```shell
 go install github.com/bazelbuild/bazelisk@latest
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bazelbuild/bazelisk
 
-go 1.18
+go 1.22
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d


### PR DESCRIPTION
As mentioned in the [Go Security Policy](https://go.dev/doc/security/#security-policysecuritypolicy), the [Release Policy](https://go.dev/doc/devel/release#policy) states:

> Each major Go release is supported until there are two newer major releases.

Therefore, Go `1.20` is End of Life and must be updated. This has security implications as reported by https://github.com/bazelbuild/bazelisk/issues/583

This PR upgrades Go to `1.22.5`, which currently is the latest release.

Fixes https://github.com/bazelbuild/bazelisk/issues/583

// cc: @creste