### PR TITLE
Add Windows ARM64 and Refactored Targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@gazelle//:def.bzl", "gazelle")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package", "stamped_package_json")
+load("@gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk
 gazelle(name = "gazelle")

--- a/BUILD
+++ b/BUILD
@@ -73,33 +73,43 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-go_binary(
-    name = "bazelisk-darwin-amd64",
-    out = "bazelisk-darwin_amd64",
-    embed = [":bazelisk_lib"],
-    gc_linkopts = [
-        "-s",
-        "-w",
-    ],
-    goarch = "amd64",
-    goos = "darwin",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
+[
+    go_binary(
+        name = "bazelisk-%s-%s" % (os, arch),
+        out = "bazelisk-%s_%s" % (os, arch),
+        embed = [":bazelisk_lib"],
+        gc_linkopts = [
+            "-s",
+            "-w",
+        ],
+        goarch = arch,
+        goos = os,
+        pure = "on",
+        visibility = ["//visibility:public"],
+    )
+    for os, arch in [
+        ("darwin", "amd64"),
+        ("darwin", "arm64"),
+        ("linux", "amd64"),
+        ("linux", "arm64")
+    ]
+]
 
-go_binary(
-    name = "bazelisk-darwin-arm64",
-    out = "bazelisk-darwin_arm64",
-    embed = [":bazelisk_lib"],
-    gc_linkopts = [
-        "-s",
-        "-w",
-    ],
-    goarch = "arm64",
-    goos = "darwin",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
+[
+    go_binary(
+        name = "bazelisk-%s-%s" % (os, arch),
+        out = "bazelisk-%s_%s.exe" % (os, arch),
+        embed = [":bazelisk_lib"],
+        goarch = arch,
+        goos = os,
+        pure = "on",
+        visibility = ["//visibility:public"],
+    )
+    for os, arch in [
+        ("windows", "amd64"),
+        ("windows", "arm64")
+    ]
+]
 
 genrule(
     name = "bazelisk-darwin-universal",
@@ -113,44 +123,6 @@ genrule(
     target_compatible_with = [
         "@platforms//os:macos",
     ],
-)
-
-go_binary(
-    name = "bazelisk-linux-amd64",
-    out = "bazelisk-linux_amd64",
-    embed = [":bazelisk_lib"],
-    gc_linkopts = [
-        "-s",
-        "-w",
-    ],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-go_binary(
-    name = "bazelisk-linux-arm64",
-    out = "bazelisk-linux_arm64",
-    embed = [":bazelisk_lib"],
-    gc_linkopts = [
-        "-s",
-        "-w",
-    ],
-    goarch = "arm64",
-    goos = "linux",
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
-
-go_binary(
-    name = "bazelisk-windows-amd64",
-    out = "bazelisk-windows_amd64.exe",
-    embed = [":bazelisk_lib"],
-    goarch = "amd64",
-    goos = "windows",
-    pure = "on",
-    visibility = ["//visibility:public"],
 )
 
 stamped_package_json(
@@ -171,6 +143,7 @@ npm_package(
         ":bazelisk-linux-amd64",
         ":bazelisk-linux-arm64",
         ":bazelisk-windows-amd64",
+        ":bazelisk-windows-arm64",
         ":package",
     ],
     package = "@bazel/bazelisk",

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@gazelle//:def.bzl", "gazelle")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package", "stamped_package_json")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk

--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,7 @@ load("@aspect_rules_js//npm:defs.bzl", "npm_package", "stamped_package_json")
 load("@gazelle//:def.bzl", "gazelle")
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
+# gazelle:ignore
 # gazelle:prefix github.com/bazelbuild/bazelisk
 gazelle(name = "gazelle")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 bazel_dep(name = "gazelle", version = "0.38.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_go", version = "0.49.0")
-bazel_dep(name = "aspect_rules_js", version = "1.39.1")
+bazel_dep(name = "aspect_rules_js", version = "1.42.3")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.22.5")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,14 +1,14 @@
 module(name = "bazelisk", version="")
 
-bazel_dep(name = "gazelle", version = "0.38.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.38.0")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_go", version = "0.49.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.49.0")
 bazel_dep(name = "aspect_rules_js", version = "1.39.1")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.22.5")
 
-go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,7 @@
-module(name = "bazelisk", version="")
+module(
+    name = "bazelisk",
+    version = "",
+)
 
 bazel_dep(name = "gazelle", version = "0.38.0")
 bazel_dep(name = "platforms", version = "0.0.10")
@@ -12,8 +15,8 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,
+    "com_github_bgentry_go_netrc",
     "com_github_hashicorp_go_version",
     "com_github_mitchellh_go_homedir",
-    "com_github_bgentry_go_netrc",
     "org_golang_x_term",
 )

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,8 @@ go build
     //:bazelisk-darwin-universal \
     //:bazelisk-linux-amd64 \
     //:bazelisk-linux-arm64 \
-    //:bazelisk-windows-amd64
+    //:bazelisk-windows-amd64 \
+    //:bazelisk-windows-arm64
 echo
 
 cp bazel-out/*-opt*/bin/bazelisk-darwin_amd64 bin/bazelisk-darwin-amd64
@@ -36,6 +37,7 @@ cp bazel-out/*-opt*/bin/bazelisk-darwin_universal bin/bazelisk-darwin
 cp bazel-out/*-opt*/bin/bazelisk-linux_amd64 bin/bazelisk-linux-amd64
 cp bazel-out/*-opt*/bin/bazelisk-linux_arm64 bin/bazelisk-linux-arm64
 cp bazel-out/*-opt*/bin/bazelisk-windows_amd64.exe bin/bazelisk-windows-amd64.exe
+cp bazel-out/*-opt*/bin/bazelisk-windows_arm64.exe bin/bazelisk-windows-arm64.exe
 rm -f bazelisk
 
 ### Build release artifacts using `go build`.
@@ -45,6 +47,7 @@ rm -f bazelisk
 # GOOS=darwin GOARCH=arm64 go build -o bin/bazelisk-darwin-arm64
 # lipo -create -output bin/bazelisk-darwin bin/bazelisk-darwin-amd64 bin/bazelisk-darwin-arm64
 # GOOS=windows GOARCH=amd64 go build -o bin/bazelisk-windows-amd64.exe
+# GOOS=windows GOARCH=arm64 go build -o bin/bazelisk-windows-arm64.exe
 
 ### Print some information about the generated binaries.
 echo "== Bazelisk binaries are ready =="

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "config",

--- a/config/BUILD
+++ b/config/BUILD
@@ -5,8 +5,5 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/bazelbuild/bazelisk/config",
     visibility = ["//visibility:public"],
-    deps = [
-        "//ws",
-        "@com_github_mitchellh_go_homedir//:go_default_library",
-    ],
+    deps = ["//ws"],
 )

--- a/core/BUILD
+++ b/core/BUILD
@@ -15,7 +15,7 @@ go_library(
         "//platforms",
         "//versions",
         "//ws",
-        "@com_github_mitchellh_go_homedir//:go_default_library",
+        "@com_github_mitchellh_go_homedir//:go-homedir",
     ],
 )
 
@@ -28,5 +28,6 @@ go_test(
     embed = [":core"],
     deps = [
         "//config",
+        "//platforms",
     ],
 )

--- a/core/BUILD
+++ b/core/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "core",

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -15,15 +15,13 @@ go_library(
     deps = [
         "//config",
         "//httputil/progress",
-        "@com_github_bgentry_go_netrc//netrc:go_default_library",
-        "@com_github_mitchellh_go_homedir//:go_default_library",
+        "@com_github_bgentry_go_netrc//netrc",
+        "@com_github_mitchellh_go_homedir//:go-homedir",
     ],
 )
 
 go_test(
     name = "httputil_test",
-    srcs = [
-        "httputil_test.go",
-    ],
+    srcs = ["httputil_test.go"],
     embed = [":httputil"],
 )

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk/httputil
 gazelle(name = "gazelle")

--- a/httputil/progress/BUILD
+++ b/httputil/progress/BUILD
@@ -6,21 +6,17 @@ gazelle(name = "gazelle")
 
 go_library(
     name = "progress",
-    srcs = [
-        "progress.go",
-    ],
+    srcs = ["progress.go"],
     importpath = "github.com/bazelbuild/bazelisk/httputil/progress",
     visibility = ["//visibility:public"],
     deps = [
         "//config",
-        "@org_golang_x_term//:go_default_library",
+        "@org_golang_x_term//:term",
     ],
 )
 
 go_test(
     name = "progress_test",
-    srcs = [
-        "progress_test.go",
-    ],
+    srcs = ["progress_test.go"],
     embed = [":progress"],
 )

--- a/httputil/progress/BUILD
+++ b/httputil/progress/BUILD
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk/httputil/progress
 gazelle(name = "gazelle")

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "platforms",

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//config",
         "//versions",
-        "@com_github_hashicorp_go_version//:go_default_library",
+        "@com_github_hashicorp_go_version//:go-version",
     ],
 )
 

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "repositories",

--- a/versions/BUILD
+++ b/versions/BUILD
@@ -6,6 +6,6 @@ go_library(
     importpath = "github.com/bazelbuild/bazelisk/versions",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_hashicorp_go_version//:go_default_library",
+        "@com_github_hashicorp_go_version//:go-version",
     ],
 )

--- a/versions/BUILD
+++ b/versions/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "versions",

--- a/ws/BUILD
+++ b/ws/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ws",

--- a/ws/BUILD
+++ b/ws/BUILD
@@ -1,11 +1,8 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ws",
     srcs = ["ws.go"],
     importpath = "github.com/bazelbuild/bazelisk/ws",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_mitchellh_go_homedir//:go_default_library",
-    ],
 )

--- a/ws/ws.go
+++ b/ws/ws.go
@@ -24,7 +24,7 @@ func FindWorkspaceRoot(root string) string {
 
 // isValidWorkspace returns true if the supplied path is the workspace root, defined by the presence of
 // a file named MODULE.bazel, REPO.bazel, WORKSPACE.bazel, or WORKSPACE
-// see https://github.com/bazelbuild/bazel/blob/6.3.0/src/main/cpp/workspace_layout.cc#L34
+// see https://github.com/bazelbuild/bazel/blob/7.2.1/src/main/cpp/workspace_layout.cc#L34
 func isValidWorkspace(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
# Summary

Gazelle targets haven't been updated in a while. Took this opportunity to re-generate them.

Also, the `BUILD` file had many `go_binary` directives even though there are just two flavors: a stripped binary and another with all the symbols. Refactored to dinamically generate those based on the `os`, `arch` we should have for each flavor.

Added `windows-arm64`, tested in a workstation on Azure. Find evidence below.


> [!WARNING]  
> **bazelisk.js**: The NodeJS version installed in the machine must be ARM, otherwise `os.arch()` returns `x64` and it will use the `windows_amd64` binary.

Installed from: `npm i -g @bazel/bazelisk --registry=https://albertocavalcante.jfrog.io/artifactory/api/npm/bazel-npm-local`

# Test Evidence

Tested on a Windows ARM4 machine.

![system-about](https://github.com/user-attachments/assets/67f3ce3e-c196-43b4-80bb-2b4fb1754b0d)


![node bazelisk.js](https://github.com/user-attachments/assets/5266c85f-96b0-4059-b071-565111d62e4d)

![content of @bazel/bazelisk](https://github.com/user-attachments/assets/c46607e5-b4d2-4a9d-86d4-ba8135c3d517)

Context: https://github.com/bazelbuild/bazel/issues/22164

Fixes https://github.com/bazelbuild/bazelisk/issues/572