### PR TITLE
Fetch bazel binaries for commits on linux arm64

### DIFF
--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -22,8 +22,8 @@ var supportedPlatforms = map[string]*platform{
 		HasArm64Binary: true,
 	},
 	"linux": {
-		Name:           "centos7",
-		HasArm64Binary: false,
+		Name:           "linux",
+		HasArm64Binary: true,
 	},
 	"windows": {
 		Name:           "windows",


### PR DESCRIPTION
Depends on https://github.com/bazelbuild/continuous-integration/pull/2022

Fixes https://github.com/bazelbuild/bazelisk/issues/317

Bazel commits after https://github.com/bazelbuild/bazel/commit/5aaffc3aad61b003be3996af17641afedee9a2ec will be supported for Linux arm64.

We've been publishing under both "linux" and "centos7" for x64 binaries for a long time, so it should be fine to switch the name.