### PR TITLE
Fix & re-enable test_path_is_consistent_regardless_of_base_url

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -329,7 +329,7 @@ EOF
 function test_path_is_consistent_regardless_of_base_url() {
   setup
 
-  echo 6.2.0 > .bazelversion
+  echo 7.3.1 > .bazelversion
 
   cat >WORKSPACE <<EOF
 load("//:print_path.bzl", "print_path")
@@ -577,10 +577,9 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
   test_bazel_prepend_binary_directory_to_path_go
   echo
 
-  # Disabled due to https://github.com/bazelbuild/bazelisk/pull/465#issuecomment-1805905082
-  # echo "# test_path_is_consistent_regardless_of_base_url"
-  # test_path_is_consistent_regardless_of_base_url
-  # echo
+  echo "# test_path_is_consistent_regardless_of_base_url"
+  test_path_is_consistent_regardless_of_base_url
+  echo
 
   case "$(uname -s)" in
     MSYS*)


### PR DESCRIPTION
sourceforge no longer hosts Bazel 6.2, so I had to use a newer version instead.