### PR TITLE
Improve last green commit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ Bazelisk currently understands the following formats for version labels:
 Additionally, a few special version names are supported for our official releases only (these formats do not work when using a fork):
 - `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).
   Ideally this binary should be very close to Bazel-at-head.
-- `last_downstream_green` points to the most recent Bazel binary that builds and tests all [downstream projects](https://buildkite.com/bazel/bazel-at-head-plus-downstream) successfully.
 - `last_rc` points to the most recent release candidate.
   If there is no active release candidate, Bazelisk uses the latest Bazel release instead.
 - `rolling` refers to the latest rolling release (even if there is a newer LTS release).
+
+Note: `last_downstream_green` support has been removed, please use `last_green` instead.
 
 ## Where does Bazelisk get Bazel from?
 
@@ -219,7 +220,7 @@ Additionally, the Bazelisk home directory is also evaluated in precedence order.
 
 For ease of use, the Python version of Bazelisk is written to work with Python 2.7 and 3.x and only uses modules provided by the standard library.
 
-The Go version can be compiled to run natively on Linux, macOS and Windows. 
+The Go version can be compiled to run natively on Linux, macOS and Windows.
 
 To install it, run:
 

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -46,14 +46,9 @@ ONE_HOUR = 1 * 60 * 60
 
 LATEST_PATTERN = re.compile(r"latest(-(?P<offset>\d+))?$")
 
-LAST_GREEN_COMMIT_BASE_PATH = (
-    "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/"
+LAST_GREEN_COMMIT_PATH = (
+    "https://storage.googleapis.com/bazel-builds/last_green_commit/github.com/bazelbuild/bazel.git/publish-bazel-binaries"
 )
-
-LAST_GREEN_COMMIT_PATH_SUFFIXES = {
-    "last_green": "github.com/bazelbuild/bazel.git/bazel-bazel",
-    "last_downstream_green": "downstream_pipeline",
-}
 
 BAZEL_GCS_PATH_PATTERN = (
     "https://storage.googleapis.com/bazel-builds/artifacts/{platform}/{commit}/bazel"
@@ -119,9 +114,8 @@ def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
             of an unreleased Bazel binary,
         2. An indicator for whether the returned version refers to a commit.
     """
-    suffix = LAST_GREEN_COMMIT_PATH_SUFFIXES.get(version)
-    if suffix:
-        return get_last_green_commit(suffix), True
+    if version == "last_green":
+        return get_last_green_commit(), True
 
     if "latest" in version:
         match = LATEST_PATTERN.match(version)
@@ -140,8 +134,11 @@ def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
     return version, False
 
 
-def get_last_green_commit(path_suffix):
-    return read_remote_text_file(LAST_GREEN_COMMIT_BASE_PATH + path_suffix).strip()
+def get_last_green_commit():
+    commit = read_remote_text_file(LAST_GREEN_COMMIT_PATH).strip()
+    if not re.match(r"^[0-9a-f]{40}$", commit):
+        raise Exception("Invalid commit hash: {}".format(commit))
+    return commit
 
 
 def get_releases_json(bazelisk_directory):

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -257,17 +257,6 @@ function test_bazel_last_green() {
       (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
 }
 
-function test_bazel_last_downstream_green() {
-  setup
-
-  USE_BAZEL_VERSION="last_downstream_green" \
-      BAZELISK_HOME="$BAZELISK_HOME" \
-      bazelisk version 2>&1 | tee log
-
-  ! grep "Build label:" log || \
-      (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
-}
-
 function test_BAZELISK_NOJDK() {
   setup
 
@@ -514,10 +503,6 @@ echo
 
 echo "# test_bazel_last_green"
 test_bazel_last_green
-echo
-
-echo "# test_bazel_last_downstream_green"
-test_bazel_last_downstream_green
 echo
 
 echo "# test_BAZELISK_NOJDK"

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,6 @@ env -u USE_BAZEL_VERSION ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="latest" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="0.28.0" ./bin/bazelisk-darwin-amd64 version
 USE_BAZEL_VERSION="last_green" ./bin/bazelisk-darwin-"$arch" version
-USE_BAZEL_VERSION="last_downstream_green" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="last_rc" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="bazelbuild/latest" ./bin/bazelisk-darwin-"$arch" version
 USE_BAZEL_VERSION="bazelbuild/0.27.0" ./bin/bazelisk-darwin-amd64 version

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -27,7 +27,7 @@ var (
 
 // Info represents a structured Bazel version identifier.
 type Info struct {
-	IsRelease, IsCandidate, IsCommit, IsFork, IsRolling, IsRelative, IsDownstream bool
+	IsRelease, IsCandidate, IsCommit, IsFork, IsRolling, IsRelative bool
 	Fork, Value                                                                   string
 	LatestOffset, TrackRestriction                                                int
 }
@@ -68,10 +68,6 @@ func Parse(fork, version string) (*Info, error) {
 	} else if version == "last_green" {
 		vi.IsCommit = true
 		vi.IsRelative = true
-	} else if version == "last_downstream_green" {
-		vi.IsCommit = true
-		vi.IsRelative = true
-		vi.IsDownstream = true
 	} else if rollingPattern.MatchString(version) {
 		vi.IsRolling = true
 	} else if version == "rolling" {
@@ -106,7 +102,11 @@ func GetInAscendingOrder(versions []string) []string {
 	return sorted
 }
 
+func MatchCommitPattern(version string) bool {
+	return commitPattern.MatchString(version)
+}
+
 // IsCommit returns whether the given version refers to a commit.
 func IsCommit(version string) bool {
-	return version == "last_green" || version == "last_downstream_green" || commitPattern.MatchString(version)
+	return version == "last_green" || commitPattern.MatchString(version)
 }


### PR DESCRIPTION
- Fetch last green commit from `https://storage.googleapis.com/bazel-builds/last_green_commit/github.com/bazelbuild/bazel.git/publish-bazel-binaries` which is generated by the trusted Bazel CI org.
- Validate the format of the commit hash fetched
- Removed support for `last_downstream_green`. The [downstream pipeline](https://buildkite.com/bazel/bazel-at-head-plus-downstream) hasn't been green for more than a year, there is not much point of using this commit for fetching Bazel binary.