### PR TITLE
Restore npm publish target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -147,4 +147,5 @@ npm_package(
         ":package",
     ],
     package = "@bazel/bazelisk",
+    publishable = True,
 )


### PR DESCRIPTION
build.sh builds //:npm_package.publish, which recently disappeared due to a combination of https://github.com/aspect-build/rules_js/pull/1683 and https://github.com/bazelbuild/bazelisk/pull/610.