### PR TITLE
Fix races on temporary file copies

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -409,6 +409,7 @@ func atomicWriteFile(path string, contents []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to MkdirAll parent of %s: %w", path, err)
 	}
 	tmpFile, err := os.CreateTemp(parent, filepath.Base(path)+".tmp")
+	tmpFile.Close()
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file in %s: %w", parent, err)
 	}
@@ -472,6 +473,7 @@ func downloadBazelToCAS(version string, bazeliskHome string, repos *Repositories
 	}
 
 	tmpPathFile, err := os.CreateTemp(dirForBazelInCAS, bazelInCASBasename+".tmp")
+	tmpPathFile.Close()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temporary file in %s: %w", dirForBazelInCAS, err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -404,10 +404,16 @@ func downloadBazelIfNecessary(version string, bazeliskHome string, bazelForkOrUR
 }
 
 func atomicWriteFile(path string, contents []byte, perm os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0755); err != nil {
 		return fmt.Errorf("failed to MkdirAll parent of %s: %w", path, err)
 	}
-	tmpPath := path + ".tmp"
+	tmpFile, err := os.CreateTemp(parent, filepath.Base(path)+".tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file in %s: %w", parent, err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpPath := tmpFile.Name()
 	if err := os.WriteFile(tmpPath, contents, perm); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", tmpPath, err)
 	}
@@ -458,12 +464,19 @@ func downloadBazelToCAS(version string, bazeliskHome string, repos *Repositories
 	f.Close()
 	actualSha256 := strings.ToLower(fmt.Sprintf("%x", h.Sum(nil)))
 
-	pathToBazelInCAS := filepath.Join(casDir, actualSha256, "bin", "bazel"+platforms.DetermineExecutableFilenameSuffix())
-	if err := os.MkdirAll(filepath.Dir(pathToBazelInCAS), 0755); err != nil {
+	bazelInCASBasename := "bazel" + platforms.DetermineExecutableFilenameSuffix()
+	pathToBazelInCAS := filepath.Join(casDir, actualSha256, "bin", bazelInCASBasename)
+	dirForBazelInCAS := filepath.Dir(pathToBazelInCAS)
+	if err := os.MkdirAll(dirForBazelInCAS, 0755); err != nil {
 		return "", "", fmt.Errorf("failed to MkdirAll parent of %s: %w", pathToBazelInCAS, err)
 	}
 
-	tmpPathInCorrectDirectory := pathToBazelInCAS + ".tmp"
+	tmpPathFile, err := os.CreateTemp(dirForBazelInCAS, bazelInCASBasename+".tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temporary file in %s: %w", dirForBazelInCAS, err)
+	}
+	defer os.Remove(tmpPathFile.Name())
+	tmpPathInCorrectDirectory := tmpPathFile.Name()
 	if err := os.Rename(tmpDestPath, tmpPathInCorrectDirectory); err != nil {
 		return "", "", fmt.Errorf("failed to move %s to %s: %w", tmpDestPath, tmpPathInCorrectDirectory, err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -409,10 +409,10 @@ func atomicWriteFile(path string, contents []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to MkdirAll parent of %s: %w", path, err)
 	}
 	tmpFile, err := os.CreateTemp(parent, filepath.Base(path)+".tmp")
-	tmpFile.Close()
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file in %s: %w", parent, err)
 	}
+	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
 	tmpPath := tmpFile.Name()
 	if err := os.WriteFile(tmpPath, contents, perm); err != nil {
@@ -473,10 +473,10 @@ func downloadBazelToCAS(version string, bazeliskHome string, repos *Repositories
 	}
 
 	tmpPathFile, err := os.CreateTemp(dirForBazelInCAS, bazelInCASBasename+".tmp")
-	tmpPathFile.Close()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temporary file in %s: %w", dirForBazelInCAS, err)
 	}
+	tmpPathFile.Close()
 	defer os.Remove(tmpPathFile.Name())
 	tmpPathInCorrectDirectory := tmpPathFile.Name()
 	if err := os.Rename(tmpDestPath, tmpPathInCorrectDirectory); err != nil {


### PR DESCRIPTION
When two instances of Bazelisk are running concurrently and downloading Bazel, the current code admits a race. This patch fixes the issue by using randomly named files for temporary paths.

For example:

```
{"error":"could not download Bazel: failed to download bazel: failed to move /root/.bazel_binaries/stripe-bazel/downloads/sha256/09bac5c11165a6ab0b7a90d6937c8bc3fcdcda662ffe0590e87ac2ae0e5e8978/bin/bazel.tmp to /root/.bazel_binaries/stripe-bazel/downloads/sha256/09bac5c11165a6ab0b7a90d6937c8bc3fcdcda662ffe0590e87ac2ae0e5e8978/bin/bazel: rename /root/.bazel_binaries/stripe-bazel/downloads/sha256/09bac5c11165a6ab0b7a90d6937c8bc3fcdcda662ffe0590e87ac2ae0e5e8978/bin/bazel.tmp /root/.bazel_binaries/stripe-bazel/downloads/sha256/09bac5c11165a6ab0b7a90d6937c8bc3fcdcda662ffe0590e87ac2ae0e5e8978/bin/bazel: no such file or directory"}
```