### PR TITLE
Refactor repositories API

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -27,8 +27,8 @@ func main() {
 	gcs := &repositories.GCSRepo{}
 	config := core.MakeDefaultConfig()
 	gitHub := repositories.CreateGitHubRepo(config.Get("BAZELISK_GITHUB_TOKEN"))
-	// Fetch LTS releases, release candidates, rolling releases and Bazel-at-commits from GCS, forks from GitHub.
-	repos := core.CreateRepositories(gcs, gcs, gitHub, gcs, gcs, true)
+	// Fetch LTS releases & candidates, rolling releases and Bazel-at-commits from GCS, forks from GitHub.
+	repos := core.CreateRepositories(gcs, gitHub, gcs, gcs, true)
 
 	exitCode, err := core.RunBazeliskWithArgsFuncAndConfig(func(string) []string { return os.Args[1:] }, repos, config)
 	if err != nil {

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,35 +20,35 @@ import (
 )
 
 const (
-	candidateBaseURL    = "https://releases.bazel.build"
-	nonCandidateBaseURL = "https://storage.googleapis.com/bazel-builds/artifacts"
-	lastGreenCommitURL  = "https://storage.googleapis.com/bazel-builds/last_green_commit/github.com/bazelbuild/bazel.git/publish-bazel-binaries"
+	ltsBaseURL         = "https://releases.bazel.build"
+	commitBaseURL      = "https://storage.googleapis.com/bazel-builds/artifacts"
+	lastGreenCommitURL = "https://storage.googleapis.com/bazel-builds/last_green_commit/github.com/bazelbuild/bazel.git/publish-bazel-binaries"
 )
 
 // GCSRepo represents a Bazel repository on Google Cloud Storage that contains Bazel releases, release candidates and Bazel binaries built at arbitrary commits.
 // It can return all available Bazel versions, as well as downloading a specific version.
 type GCSRepo struct{}
 
-// ReleaseRepo
+// LTSRepo
 
-// GetReleaseVersions returns the versions of all available Bazel releases in this repository that match the given filter.
-func (gcs *GCSRepo) GetReleaseVersions(bazeliskHome string, filter core.ReleaseFilter) ([]string, error) {
+// GetLTSVersions returns the versions of all available Bazel releases in this repository that match the given filter.
+func (gcs *GCSRepo) GetLTSVersions(bazeliskHome string, opts *core.FilterOpts) ([]string, error) {
 	history, err := getVersionHistoryFromGCS()
 	if err != nil {
 		return []string{}, err
 	}
-	releases, err := gcs.removeCandidates(history, filter)
+	matches, err := gcs.matchingVersions(history, opts)
 	if err != nil {
 		return []string{}, err
 	}
-	if len(releases) == 0 {
-		return []string{}, errors.New("there are no releases available")
+	if len(matches) == 0 {
+		return []string{}, errors.New("there are no LTS releases or candidates")
 	}
-	return releases, nil
+	return matches, nil
 }
 
 func getVersionHistoryFromGCS() ([]string, error) {
-	prefixes, _, err := listDirectoriesInReleaseBucket("")
+	prefixes, err := listDirectoriesInBucket("")
 	if err != nil {
 		return []string{}, fmt.Errorf("could not list Bazel versions in GCS bucket: %v", err)
 	}
@@ -57,14 +58,13 @@ func getVersionHistoryFromGCS() ([]string, error) {
 	return sorted, nil
 }
 
-func listDirectoriesInReleaseBucket(prefix string) ([]string, bool, error) {
+func listDirectoriesInBucket(prefix string) ([]string, error) {
 	baseURL := "https://www.googleapis.com/storage/v1/b/bazel/o?delimiter=/"
 	if prefix != "" {
 		baseURL = fmt.Sprintf("%s&prefix=%s", baseURL, prefix)
 	}
 
 	var prefixes []string
-	var isRelease = false
 	var nextPageToken = ""
 	for {
 		var url = baseURL
@@ -88,32 +88,22 @@ func listDirectoriesInReleaseBucket(prefix string) ([]string, bool, error) {
 		}
 
 		if err != nil {
-			return nil, false, fmt.Errorf("could not list GCS objects at %s: %v", url, err)
+			return nil, fmt.Errorf("could not list GCS objects at %s: %v", url, err)
 		}
 
 		var response GcsListResponse
 		if err := json.Unmarshal(content, &response); err != nil {
-			return nil, false, fmt.Errorf("could not parse GCS index JSON: %v", err)
+			return nil, fmt.Errorf("could not parse GCS index JSON: %v", err)
 		}
 
 		prefixes = append(prefixes, response.Prefixes...)
-		isRelease = isRelease || len(response.Items) > 0
 
 		if response.NextPageToken == "" {
 			break
 		}
 		nextPageToken = response.NextPageToken
 	}
-	return prefixes, isRelease, nil
-}
-
-func getVersionsFromGCSPrefixes(versions []string) []string {
-	result := make([]string, len(versions))
-	for i, v := range versions {
-		noSlashes := strings.Replace(v, "/", "", -1)
-		result[i] = strings.TrimSuffix(noSlashes, "release")
-	}
-	return result
+	return prefixes, nil
 }
 
 // GcsListResponse represents the result of listing the contents of a GCS bucket.
@@ -129,113 +119,77 @@ type GcsListResponse struct {
 	NextPageToken string `json:"nextPageToken"`
 }
 
-// DownloadRelease downloads the given Bazel release into the specified location and returns the absolute path.
-func (gcs *GCSRepo) DownloadRelease(version, destDir, destFile string, config config.Config) (string, error) {
-	srcFile, err := platforms.DetermineBazelFilename(version, true, config)
-	if err != nil {
-		return "", err
+func getVersionsFromGCSPrefixes(versions []string) []string {
+	result := make([]string, len(versions))
+	for i, v := range versions {
+		noSlashes := strings.Replace(v, "/", "", -1)
+		result[i] = strings.TrimSuffix(noSlashes, "release")
 	}
-
-	url := fmt.Sprintf("%s/%s/release/%s", candidateBaseURL, version, srcFile)
-	return httputil.DownloadBinary(url, destDir, destFile, config)
+	return result
 }
 
-func (gcs *GCSRepo) removeCandidates(history []string, filter core.ReleaseFilter) ([]string, error) {
-	descendingReleases := make([]string, 0)
-	filterPassed := false
-	// Iteration in descending order is important:
-	// - ReleaseFilter won't work correctly otherwise
-	// - It makes more sense in the "latest-n" use case
+func (gcs *GCSRepo) matchingVersions(history []string, opts *core.FilterOpts) ([]string, error) {
+	descendingMatches := make([]string, 0)
+	// history is a list of base versions in ascending order (i.e. X.Y.Z, no rolling releases or candidates).
 	for hpos := len(history) - 1; hpos >= 0; hpos-- {
-		latestVersion := history[hpos]
-		pass := filter(len(descendingReleases), latestVersion)
-		if pass {
-			filterPassed = true
-		} else {
-			// Underlying assumption: all matching versions are in a single continuous sequence.
-			// Consequently, if the filter returns false, this means:
-			if filterPassed {
-				// a) "break" if we've seen a match before (because all future version won't match either)
+		baseVersion := history[hpos]
+
+		if opts.Track > 0 {
+			track, err := getTrack(baseVersion)
+			if err != nil {
+				continue // Ignore invalid GCS entries for now
+			}
+			if track > opts.Track {
+				continue
+			} else if track < opts.Track {
 				break
-			} else {
-				// b) "continue looking" if we've never seen a match before
+			}
+		}
+
+		// Append slash to match directories
+		bucket := fmt.Sprintf("%s/", history[hpos])
+		prefixes, err := listDirectoriesInBucket(bucket)
+		if err != nil {
+			return []string{}, fmt.Errorf("could not list LTS releases/candidates: %v", err)
+		}
+
+		// Ascending list of rc versions, followed by the release version (if it exists) and a rolling identifier (if there are rolling releases).
+		versions := getVersionsFromGCSPrefixes(prefixes)
+		for vpos := len(versions) - 1; vpos >= 0 && len(descendingMatches) < opts.MaxResults; vpos-- {
+			curr := versions[vpos]
+			if strings.Contains(curr, "rolling") || !opts.Filter(curr) {
 				continue
 			}
-		}
-		// Obviously this only works for the existing filters (lastN and track-based) and
-		// because versions in history are sorted.
-
-		_, isRelease, err := listDirectoriesInReleaseBucket(latestVersion + "/release/")
-		if err != nil {
-			return []string{}, fmt.Errorf("could not list available releases for %v: %v", latestVersion, err)
-		}
-		if isRelease {
-			descendingReleases = append(descendingReleases, latestVersion)
+			descendingMatches = append(descendingMatches, curr)
 		}
 	}
-	return reverseInPlace(descendingReleases), nil
+	return descendingMatches, nil
 }
 
-func reverseInPlace(values []string) []string {
-	for i := 0; i < len(values)/2; i++ {
-		j := len(values) - 1 - i
-		values[i], values[j] = values[j], values[i]
+func getTrack(version string) (int, error) {
+	major, _, _ := strings.Cut(version, ".")
+	if val, err := strconv.Atoi(major); err == nil {
+		return val, nil
 	}
-	return values
+	return 0, fmt.Errorf("invalid version %q", version)
 }
 
-// CandidateRepo
-
-// GetCandidateVersions returns all versions of available release candidates for the latest release in this repository.
-func (gcs *GCSRepo) GetCandidateVersions(bazeliskHome string) ([]string, error) {
-	history, err := getVersionHistoryFromGCS()
-	if err != nil {
-		return []string{}, err
-	}
-
-	if len(history) == 0 {
-		return []string{}, errors.New("could not find any Bazel versions")
-	}
-
-	// Find most recent directory that contains any release candidates.
-	// Typically it should be the last or second-to-last, depending on whether there are new rolling releases.
-	for pos := len(history) - 1; pos >= 0; pos-- {
-		// Append slash to match directories
-		bucket := fmt.Sprintf("%s/", history[pos])
-		rcPrefixes, _, err := listDirectoriesInReleaseBucket(bucket)
-		if err != nil {
-			return []string{}, fmt.Errorf("could not list release candidates for latest release: %v", err)
-		}
-
-		rcs := make([]string, 0)
-		for _, v := range getVersionsFromGCSPrefixes(rcPrefixes) {
-			// Remove full and rolling releases
-			if strings.Contains(v, "rc") {
-				rcs = append(rcs, v)
-			}
-		}
-		if len(rcs) > 0 {
-			return rcs, nil
-		}
-	}
-	return nil, nil
-}
-
-// DownloadCandidate downloads the given release candidate into the specified location and returns the absolute path.
-func (gcs *GCSRepo) DownloadCandidate(version, destDir, destFile string, config config.Config) (string, error) {
-	if !strings.Contains(version, "rc") {
-		return "", fmt.Errorf("'%s' does not refer to a release candidate", version)
-	}
-
+// DownloadLTS downloads the given Bazel LTS release (candidate) into the specified location and returns the absolute path.
+func (gcs *GCSRepo) DownloadLTS(version, destDir, destFile string, config config.Config) (string, error) {
 	srcFile, err := platforms.DetermineBazelFilename(version, true, config)
 	if err != nil {
 		return "", err
 	}
 
-	versionComponents := strings.Split(version, "rc")
-	baseVersion := versionComponents[0]
-	rcVersion := "rc" + versionComponents[1]
-	url := fmt.Sprintf("%s/%s/%s/%s", candidateBaseURL, baseVersion, rcVersion, srcFile)
+	var baseVersion, folder string
+	if strings.Contains(version, "rc") {
+		versionComponents := strings.Split(version, "rc")
+		baseVersion, folder = versionComponents[0], "rc"+versionComponents[1]
+	} else {
+		baseVersion, folder = version, "release"
+	}
+
+	url := fmt.Sprintf("%s/%s/%s/%s", ltsBaseURL, baseVersion, folder, srcFile)
 	return httputil.DownloadBinary(url, destDir, destFile, config)
 }
 
@@ -264,7 +218,7 @@ func (gcs *GCSRepo) DownloadAtCommit(commit, destDir, destFile string, config co
 	if err != nil {
 		return "", err
 	}
-	url := fmt.Sprintf("%s/%s/%s/bazel", nonCandidateBaseURL, platform, commit)
+	url := fmt.Sprintf("%s/%s/%s/bazel", commitBaseURL, platform, commit)
 	return httputil.DownloadBinary(url, destDir, destFile, config)
 }
 
@@ -278,7 +232,7 @@ func (gcs *GCSRepo) GetRollingVersions(bazeliskHome string) ([]string, error) {
 	}
 
 	newest := history[len(history)-1]
-	versions, _, err := listDirectoriesInReleaseBucket(newest + "/rolling/")
+	versions, err := listDirectoriesInBucket(newest + "/rolling/")
 	if err != nil {
 		return []string{}, err
 	}
@@ -301,6 +255,6 @@ func (gcs *GCSRepo) DownloadRolling(version, destDir, destFile string, config co
 	}
 
 	releaseVersion := strings.Split(version, "-")[0]
-	url := fmt.Sprintf("%s/%s/rolling/%s/%s", candidateBaseURL, releaseVersion, version, srcFile)
+	url := fmt.Sprintf("%s/%s/rolling/%s/%s", ltsBaseURL, releaseVersion, version, srcFile)
 	return httputil.DownloadBinary(url, destDir, destFile, config)
 }

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -17,7 +17,8 @@ const (
 )
 
 var (
-	releasePattern       = regexp.MustCompile(`^(\d+)\.(x|\d+\.\d+)$`)
+	releasePattern       = regexp.MustCompile(`^(\d+)\.\d+\.\d+$`)
+	trackPattern         = regexp.MustCompile(`^(\d+)\.x$`)
 	patchPattern         = regexp.MustCompile(`^(\d+\.\d+\.\d+)-([\w\d]+)$`)
 	candidatePattern     = regexp.MustCompile(`^(\d+\.\d+\.\d+)rc(\d+)$`)
 	rollingPattern       = regexp.MustCompile(`^\d+\.0\.0-pre\.\d{8}(\.\d+){1,2}$`)
@@ -27,9 +28,11 @@ var (
 
 // Info represents a structured Bazel version identifier.
 type Info struct {
-	IsRelease, IsCandidate, IsCommit, IsFork, IsRolling, IsRelative bool
-	Fork, Value                                                                   string
-	LatestOffset, TrackRestriction                                                int
+	IsRelease, IsCandidate         bool
+	IsLTS, IsRolling               bool
+	IsCommit, IsFork, IsRelative   bool
+	Fork, Value                    string
+	LatestOffset, TrackRestriction int
 }
 
 // Parse extracts and returns structured information about the given Bazel version label.
@@ -37,18 +40,22 @@ func Parse(fork, version string) (*Info, error) {
 	vi := &Info{Fork: fork, Value: version, IsFork: isFork(fork)}
 
 	if m := releasePattern.FindStringSubmatch(version); m != nil {
+		vi.IsLTS = true
 		vi.IsRelease = true
-		if m[2] == "x" {
-			track, err := strconv.Atoi(m[1])
-			if err != nil {
-				return nil, fmt.Errorf("invalid version %q, expected something like '5.2.1' or '5.x'", version)
-			}
-			vi.IsRelative = true
-			vi.TrackRestriction = track
+	} else if m := trackPattern.FindStringSubmatch(version); m != nil {
+		track, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid version %q, expected something like '5.x'", version)
 		}
+		vi.IsLTS = true
+		vi.IsRelease = true
+		vi.IsRelative = true
+		vi.TrackRestriction = track
 	} else if patchPattern.MatchString(version) {
+		vi.IsLTS = true
 		vi.IsRelease = true
 	} else if m := latestReleasePattern.FindStringSubmatch(version); m != nil {
+		vi.IsLTS = true
 		vi.IsRelease = true
 		vi.IsRelative = true
 		if m[1] != "" {
@@ -59,8 +66,10 @@ func Parse(fork, version string) (*Info, error) {
 			vi.LatestOffset = offset
 		}
 	} else if candidatePattern.MatchString(version) {
+		vi.IsLTS = true
 		vi.IsCandidate = true
 	} else if version == "last_rc" {
+		vi.IsLTS = true
 		vi.IsCandidate = true
 		vi.IsRelative = true
 	} else if commitPattern.MatchString(version) {
@@ -74,7 +83,7 @@ func Parse(fork, version string) (*Info, error) {
 		vi.IsRolling = true
 		vi.IsRelative = true
 	} else {
-		return nil, fmt.Errorf("Invalid version '%s'", version)
+		return nil, fmt.Errorf("invalid version '%s'", version)
 	}
 	return vi, nil
 }


### PR DESCRIPTION
This commit merges ReleaseRepo with CandidateRepo into a single type called LTSRepo.

1. The new behavior more closely resembles reality.
2. It will be much easier to implement https://github.com/bazelbuild/bazelisk/issues/630.

Progress towards https://github.com/bazelbuild/bazelisk/issues/630.