### PR TITLE
bisect: always override oldCommit to the merge base commit

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -824,9 +824,9 @@ func getBazelCommitsBetween(oldCommit string, newCommit string, config config.Co
 		}
 
 		mergeBaseCommit := compResp.MergeBaseCommit.SHA
+		oldCommit = mergeBaseCommit
 		if mergeBaseCommit != compResp.BaseCommit.SHA {
 			fmt.Printf("The old Bazel commit is not an ancestor of the new Bazel commit, overriding the old Bazel commit to the merge base commit %s\n", mergeBaseCommit)
-			oldCommit = mergeBaseCommit
 		}
 
 		for _, commit := range compResp.Commits {


### PR DESCRIPTION
This would resolve branch name like `release-8.0.0rc2` to an actual commit hash, which is then a valid Bazel version for Bazelisk. 

This avoids error like:
```
# bazel --bisect=release-8.0.0rc2..e18aad1be363fe40bad2cc67462a6389f381096b test //...


--- Getting the list of commits between release-8.0.0rc2 and e18aad1be363fe40bad2cc67462a6389f381096b

Found 54 commits between (release-8.0.0rc2, e18aad1be363fe40bad2cc67462a6389f381096b]


--- Verifying if the given good Bazel commit (release-8.0.0rc2) is actually good

2024/11/18 12:58:03 could not run Bazel: could not download Bazel: could not resolve the version 'release-8.0.0rc2' to an actual version number: Invalid version 'release-8.0.0rc2'
```