### PR TITLE
Implement wildcard version identifier "N.*"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Bazelisk currently understands the following formats for version labels:
   Previous releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel.
   It can also be a release candidate version like `0.20.0rc3`, or a rolling release version like `5.0.0-pre.20210317.1`.
-- A floating version identifier like `4.x` that returns the latest release from the LTS series started by Bazel 4.0.0.
+- A floating version identifier like `4.x` that returns the latest **release** from the LTS series started by Bazel 4.0.0.
+- A wildcard version identifier like `4.*` that returns the latest **release or candidate** from the LTS series started by Bazel 4.0.0.
 - The hash of a Git commit. Please note that Bazel binaries are only available for commits that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel).
 
 Additionally, a few special version names are supported for our official releases only (these formats do not work when using a fork):

--- a/bazelisk_version_test.go
+++ b/bazelisk_version_test.go
@@ -264,7 +264,7 @@ func TestAcceptTrackBasedReleaseVersions(t *testing.T) {
 		wantVersion      string
 	}{
 		{
-			name:             "FloatingVersion_ReleaseExists",
+			name:             "Floating_ReleaseExists",
 			requestedVersion: "4.x",
 			releaseExists:    true,
 			wantVersion:      "4.2.1",

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -100,7 +100,7 @@ func (r *Repositories) ResolveVersion(bazeliskHome, fork, version string, config
 }
 
 func (r *Repositories) resolveFork(bazeliskHome string, vi *versions.Info, config config.Config) (string, DownloadFunc, error) {
-	if vi.IsRelative && (vi.IsCandidate || vi.IsCommit) {
+	if vi.IsRelative && (vi.MustBeCandidate || vi.IsCommit) {
 		return "", nil, errors.New("forks do not support last_rc and last_green")
 	}
 	lister := func(bazeliskHome string) ([]string, error) {
@@ -131,10 +131,13 @@ func (r *Repositories) resolveLTS(bazeliskHome string, vi *versions.Info, config
 		Track:      vi.TrackRestriction,
 	}
 
-	if vi.IsRelease {
+	if vi.MustBeRelease {
 		opts.Filter = IsRelease
-	} else {
+	} else if vi.MustBeCandidate {
 		opts.Filter = IsCandidate
+	} else {
+		// Wildcard -> can be either release or candidate
+		opts.Filter = func(v string) bool { return true }
 	}
 
 	lister := func(bazeliskHome string) ([]string, error) {

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -133,7 +133,6 @@ func (gcs *GCSRepo) matchingVersions(history []string, opts *core.FilterOpts) ([
 	// history is a list of base versions in ascending order (i.e. X.Y.Z, no rolling releases or candidates).
 	for hpos := len(history) - 1; hpos >= 0; hpos-- {
 		baseVersion := history[hpos]
-
 		if opts.Track > 0 {
 			track, err := getTrack(baseVersion)
 			if err != nil {


### PR DESCRIPTION
Unlike the floating version identifier "N.x", "N.*" can also return release candidates.

Fixes https://github.com/bazelbuild/bazelisk/issues/630