### PR TITLE
Increased size of go_bazelisk_test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,6 +37,7 @@ sh_test(
         ":bazelisk",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
+    size = "large",
 )
 
 go_library(


### PR DESCRIPTION
Depending on the network one is using the test may go over default 5 minutes for medium size, causing spurious failures. Increased size of the test to "large" so timeout is now 15 minutes.

Sample execution on my machine:

```
$ bazel test //... --cache_test_results=no

//:bazelisk_version_test                                                 PASSED in 3.7s
//:go_bazelisk_test                                                      PASSED in 298.0s
//:py3_bazelisk_test                                                     PASSED in 52.0s
//:py_bazelisk_test                                                      PASSED in 54.5s
//core:core_test                                                         PASSED in 0.0s
//httputil:httputil_test                                                 PASSED in 0.0s
//httputil/progress:progress_test                                        PASSED in 0.0s
//platforms:platforms_test                                               PASSED in 0.0s
```