### PR TITLE
Improve error message for missing LTS binaries

### DIFF
--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -42,7 +42,11 @@ func (gcs *GCSRepo) GetLTSVersions(bazeliskHome string, opts *core.FilterOpts) (
 		return []string{}, err
 	}
 	if len(matches) == 0 {
-		return []string{}, errors.New("there are no LTS releases or candidates")
+		var suffix string
+		if opts.Track > 0 {
+			suffix = fmt.Sprintf(" for track %d", opts.Track)
+		}
+		return []string{}, fmt.Errorf("could not find any LTS Bazel binaries%s", suffix)
 	}
 	return matches, nil
 }

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -5,7 +5,6 @@ package repositories
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"


### PR DESCRIPTION
Follow-up to https://github.com/bazelbuild/bazelisk/pull/636.