### PR TITLE
Avoid unnecessary HTTP requests for latest/last_rc

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -332,7 +332,7 @@ func parseBazelForkAndVersion(bazelForkAndVersion string) (string, string, error
 	} else if len(versionInfo) == 2 {
 		bazelFork, bazelVersion = versionInfo[0], versionInfo[1]
 	} else {
-		return "", "", fmt.Errorf("invalid version \"%s\", could not parse version with more than one slash", bazelForkAndVersion)
+		return "", "", fmt.Errorf("invalid version %q, could not parse version with more than one slash", bazelForkAndVersion)
 	}
 
 	return bazelFork, bazelVersion, nil

--- a/core/repositories.go
+++ b/core/repositories.go
@@ -196,7 +196,7 @@ func resolvePotentiallyRelativeVersion(bazeliskHome string, lister listVersionsF
 
 	index := len(available) - 1 - vi.LatestOffset
 	if index < 0 {
-		return "", fmt.Errorf("cannot resolve version \"%s\": There are not enough matching Bazel releases (%d)", vi.Value, len(available))
+		return "", fmt.Errorf("cannot resolve version %q: There are not enough matching Bazel releases (%d)", vi.Value, len(available))
 	}
 	sorted := versions.GetInAscendingOrder(available)
 	return sorted[index], nil

--- a/httputil/fake.go
+++ b/httputil/fake.go
@@ -9,6 +9,8 @@ import (
 // FakeTransport represents a fake http.Transport that returns prerecorded responses.
 type FakeTransport struct {
 	responses map[string]*responseCollection
+
+	RequestedURLs []string
 }
 
 // NewFakeTransport creates a new FakeTransport instance without any responses.
@@ -38,6 +40,7 @@ func (ft *FakeTransport) AddError(url string, err error) {
 
 // RoundTrip returns a prerecorded response to the given request, if one exists. Otherwise its response indicates 404 - not found.
 func (ft *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ft.RequestedURLs = append(ft.RequestedURLs, req.URL.String())
 	if responses, ok := ft.responses[req.URL.String()]; ok {
 		return responses.Next()
 	}

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -64,7 +64,7 @@ func DetermineArchitecture(osName, version string) (string, error) {
 	case "arm64":
 		machineName = "arm64"
 	default:
-		return "", fmt.Errorf("unsupported machine architecture \"%s\", must be arm64 or x86_64", runtime.GOARCH)
+		return "", fmt.Errorf("unsupported machine architecture %q, must be arm64 or x86_64", runtime.GOARCH)
 	}
 
 	if osName == "darwin" {
@@ -80,7 +80,7 @@ func DetermineOperatingSystem() (string, error) {
 	case "darwin", "linux", "windows":
 		return runtime.GOOS, nil
 	default:
-		return "", fmt.Errorf("unsupported operating system \"%s\", must be Linux, macOS or Windows", runtime.GOOS)
+		return "", fmt.Errorf("unsupported operating system %q, must be Linux, macOS or Windows", runtime.GOOS)
 	}
 }
 

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -157,12 +157,18 @@ func (gcs *GCSRepo) matchingVersions(history []string, opts *core.FilterOpts) ([
 
 		// Ascending list of rc versions, followed by the release version (if it exists) and a rolling identifier (if there are rolling releases).
 		versions := getVersionsFromGCSPrefixes(prefixes)
-		for vpos := len(versions) - 1; vpos >= 0 && len(descendingMatches) < opts.MaxResults; vpos-- {
+		for vpos := len(versions) - 1; vpos >= 0; vpos-- {
 			curr := versions[vpos]
-			if strings.Contains(curr, "rolling") || !opts.Filter(curr) {
+			if strings.Contains(curr, "rolling") {
 				continue
 			}
-			descendingMatches = append(descendingMatches, curr)
+
+			if opts.Filter(curr) {
+				descendingMatches = append(descendingMatches, curr)
+				if len(descendingMatches) == opts.MaxResults {
+					return descendingMatches, nil
+				}
+			}
 		}
 	}
 	return descendingMatches, nil

--- a/repositories/gcs.go
+++ b/repositories/gcs.go
@@ -159,15 +159,13 @@ func (gcs *GCSRepo) matchingVersions(history []string, opts *core.FilterOpts) ([
 		versions := getVersionsFromGCSPrefixes(prefixes)
 		for vpos := len(versions) - 1; vpos >= 0; vpos-- {
 			curr := versions[vpos]
-			if strings.Contains(curr, "rolling") {
+			if strings.Contains(curr, "rolling") || !opts.Filter(curr) {
 				continue
 			}
 
-			if opts.Filter(curr) {
-				descendingMatches = append(descendingMatches, curr)
-				if len(descendingMatches) == opts.MaxResults {
-					return descendingMatches, nil
-				}
+			descendingMatches = append(descendingMatches, curr)
+			if len(descendingMatches) == opts.MaxResults {
+				return descendingMatches, nil
 			}
 		}
 	}

--- a/versions/versions.go
+++ b/versions/versions.go
@@ -61,7 +61,7 @@ func Parse(fork, version string) (*Info, error) {
 		if m[1] != "" {
 			offset, err := strconv.Atoi(m[1])
 			if err != nil {
-				return nil, fmt.Errorf("invalid version \"%s\", could not parse offset: %v", version, err)
+				return nil, fmt.Errorf("invalid version %q, could not parse offset: %v", version, err)
 			}
 			vi.LatestOffset = offset
 		}


### PR DESCRIPTION
The refactoring in https://github.com/bazelbuild/bazelisk/pull/631 introduced a severe performance regression: With latest and last_rc the code traversed *all* GCS buckets for *every* existing Bazel version. Since we send one HTTP request per bucket, this behavior led to a significant increase in HTTP requests ( >140 instead of 2-3 requests).

This commit restores the previous, correct behavior: Traversal will be stopped as soon as a matching version has been found.

Moreover, this commit adds a test to prevent similar regressions in the future.

Fixes https://github.com/bazelbuild/bazelisk/issues/640

Drive-by fix: Replaced \"%s\" with %q.