### PR TITLE
Use legacy apparent names for rules_go and gazelle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,6 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package", "stamped_package_json")
-load("@gazelle//:def.bzl", "gazelle")
-load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 # gazelle:ignore
 # gazelle:prefix github.com/bazelbuild/bazelisk

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,16 +5,16 @@ module(
     version = "",
 )
 
-bazel_dep(name = "gazelle", version = "0.38.0")
+bazel_dep(name = "gazelle", version = "0.38.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_go", version = "0.50.0")
+bazel_dep(name = "rules_go", version = "0.50.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_pkg", version = "0.10.1")
 bazel_dep(name = "aspect_rules_js", version = "2.0.1")
 
-go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.0")
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
     go_deps,

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "config",

--- a/core/BUILD
+++ b/core/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "core",

--- a/httputil/BUILD
+++ b/httputil/BUILD
@@ -1,5 +1,5 @@
-load("@gazelle//:def.bzl", "gazelle")
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk/httputil
 gazelle(name = "gazelle")

--- a/httputil/progress/BUILD
+++ b/httputil/progress/BUILD
@@ -1,5 +1,5 @@
-load("@gazelle//:def.bzl", "gazelle")
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 # gazelle:prefix github.com/bazelbuild/bazelisk/httputil/progress
 gazelle(name = "gazelle")

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "platforms",

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "repositories",

--- a/versions/BUILD
+++ b/versions/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "versions",

--- a/ws/BUILD
+++ b/ws/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ws",


### PR DESCRIPTION
When bazelisk is brought in as a Go dependency via gazelle's `go_deps` extension, it uses the repo mapping of the `gazelle` module to resolve loads. Since `gazelle` uses the legacy apparent names `bazel_gazelle` and `io_bazel_rules_go` for the `gazelle` and `rules_go` modules, the same is required for any Bazel module that is also a Go module (until gazelle gains the ability to fix load labels). 

This regressed in 4448ad1b1c77764b75a0e9a3d9605a7446f769d6.