### PR TITLE
Reset signal handling after Bazel terminates

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -699,7 +699,10 @@ func runBazel(bazel string, args []string, out io.Writer, config config.Config) 
 	// Go stack trace upon receiving SIGQUIT, which is unhelpful as users tend
 	// to report it instead of the far more valuable Java thread dump.
 	// TODO(#512): We may want to treat a `bazel run` commmand differently.
+	// Since signal handlers are process-wide global state and bazelisk may be
+	// used as a library, reset the signal handlers after the process exits.
 	signal.Ignore(syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	defer signal.Reset(syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
 	err = cmd.Wait()
 	if err != nil {


### PR DESCRIPTION
Signal handlers are process-wide global state and can affect the behavior of programs that use Bazelisk as a library.

Work towards https://github.com/buildbuddy-io/buildbuddy/issues/8326#issuecomment-2652249361