### PR TITLE
Add sha256 checksums to releases

### DIFF
--- a/.github/workflows/checksum.yaml
+++ b/.github/workflows/checksum.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright Contributors to bazelisk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Add Release Checksum
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  checksum:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Collect release
+        run: |
+          gh release download ${{ github.event.release.tag_name }} -D release
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Generate checksums.txt
+        run: |
+          cd release
+          shasum -a 256 ./* > ../checksums.txt
+      - name: Upload checksums.txt
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} checksums.txt
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Helps to try and push forward #418 and helps on uxlfoundation/oneDAL#3078  I know from the issue there was a discussion of SLSA, and that Google may be using some sort of internal release process so this may be in the wrong direction. This PR attempts to patch in a file to the release called ```checksums.txt``` which creates a text file with the sha256 hashes based on github releases using free github runners.

I have not verified its operation. Any assistance would be greatly appreciated.