### PR TITLE
Update bazelisk_test.sh

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -318,7 +318,7 @@ EOF
 function test_path_is_consistent_regardless_of_base_url() {
   setup
 
-  echo 8.0.1 > .bazelversion
+  echo 8.1.1 > .bazelversion
 
   cat >MODULE.bazel <<EOF
 print_path = use_repo_rule("//:print_path.bzl", "print_path")


### PR DESCRIPTION
8.0.1 binary no longer exists in https://sourceforge.net/projects/bazel.mirror/files/