### PR TITLE
Run buildifier to add loads

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package", "stamped_package_json")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":defs.bzl", "bazelisk_go_binaries")
 
 # gazelle:ignore
@@ -31,6 +32,7 @@ sh_test(
 
 sh_test(
     name = "go_bazelisk_test",
+    size = "large",
     srcs = ["bazelisk_test.sh"],
     args = ["GO"],
     data = [
@@ -38,7 +40,6 @@ sh_test(
         ":bazelisk",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
-    size = "large",
 )
 
 go_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_go", version = "0.50.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "aspect_rules_js", version = "2.0.1")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.0")

--- a/deb/BUILD
+++ b/deb/BUILD
@@ -17,20 +17,23 @@ genrule(
     stamp = True,
 )
 
-ARCHES = ["amd64", "arm64"]
+ARCHES = [
+    "amd64",
+    "arm64",
+]
 
 [
     pkg_tar(
         name = "bazelisk-{}_tar".format(arch),
-        out = "bazelisk-{}.tar".format(arch),
         srcs = ["//:bazelisk-linux-{}".format(arch)],
-        remap_paths = {"bazelisk-linux_{}".format(arch): "bazelisk"},
+        out = "bazelisk-{}.tar".format(arch),
         package_dir = "/usr/bin",
+        remap_paths = {"bazelisk-linux_{}".format(arch): "bazelisk"},
         stamp = -1,
         symlinks = {"bazel": "bazelisk"},
     )
     for arch in ARCHES
-] 
+]
 
 [
     pkg_deb(

--- a/defs.bzl
+++ b/defs.bzl
@@ -18,4 +18,4 @@ def bazelisk_go_binaries():
                 goos = os,
                 pure = "on",
                 visibility = ["//visibility:public"],
-           )
+            )


### PR DESCRIPTION
Run `buildifier --lint=fix  -r -v .`. This adds loads for the rules that were removed from Bazel 8. By Bazel 9 automatic loads will be disabled and all loads will need to be explicitly present.

Add dependency to `rules_shell` to `MODULE.bazel`.

See: https://github.com/bazelbuild/bazel/issues/25755