### PR TITLE
Allow `--bisect` to be interrupted

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -966,6 +966,12 @@ func bisect(oldCommit string, newCommit string, args []string, bazeliskHome stri
 		if err != nil {
 			log.Fatalf("could not run Bazel: %v", err)
 		}
+		if bazelExitCode == 8 {
+			// Bazel was interrupted, which most likely happened because the
+			// user pressed Ctrl-C. We should stop the bisecting process.
+			fmt.Printf("Bisecting was interrupted, stopping...\n")
+			os.Exit(8)
+		}
 		if bazelExitCode == 0 {
 			fmt.Printf("\n\n--- Succeeded at %s\n\n", midCommit)
 			if oldCommitIs == "good" {


### PR DESCRIPTION
Otherwise pressing Ctrl+C interrupts each individual Bazel command, but the bisection process itself continues.