### PR TITLE
Support binary tools/bazel wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,18 +171,19 @@ You can set `BAZELISK_CLEAN` to run `clean --expunge` between builds when migrat
 
 ## tools/bazel
 
-If `tools/bazel` exists in your workspace root and is executable, Bazelisk will run this file, instead of the Bazel version it downloaded.
+Bazelisk will try to run a Bazel wrapper from the `tools` directory if present, instead of the Bazel version it downloaded. When doing so, Bazelisk will set the environment variable `BAZEL_REAL` to the path of the downloaded Bazel binary. This can be useful, for example, if you have a wrapper script that ensures that environment variables are set to known good values.
 
-It will set the environment variable `BAZEL_REAL` to the path of the downloaded Bazel binary.
-This can be useful, if you have a wrapper script that e.g. ensures that environment variables are set to known good values.
+Bazelisk looks for the following wrappers, in order:
+
+* `tools/bazel.<OSNAME>-<ARCH>`: An executable that's OS- and platform-specific.
+* `tools/bazel.<ARCH>`: An executable that's platform-specific (for cases where your project only supports one operating system anyway).
+* `tools/bazel`: An executable or shell script.
+* `tools/bazel.ps1`: A PowerShell script on Windows.
+* `tools/bazel.bat`: A batch file on Windows.
+
 This behavior can be disabled by setting the environment variable `BAZELISK_SKIP_WRAPPER` to any value (except the empty string) before launching Bazelisk.
 
 You can control the user agent that Bazelisk sends in all HTTP requests by setting `BAZELISK_USER_AGENT` to the desired value.
-
-On Windows, Bazelisk will also consider the following files in addition to `tools/bazel`:
-
-* `tools/bazel.ps1` (PowerShell)
-* `tools/bazel.bat`
 
 # .bazeliskrc configuration file
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/bazelisk/config"
+	"github.com/bazelbuild/bazelisk/platforms"
 )
 
 func TestMaybeDelegateToNoWrapper(t *testing.T) {
@@ -52,6 +53,88 @@ func TestMaybeDelegateToNoNonExecutableWrapper(t *testing.T) {
 
 	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
 	expected := "bazel_real"
+
+	if entrypoint != expected {
+		t.Fatalf("Expected to delegate bazel to %q, but got %q", expected, entrypoint)
+	}
+}
+
+func TestMaybeDelegateToOsAndArchSpecificWrapper(t *testing.T) {
+	// It's not guaranteed that `tools/bazel` is executable on the
+	// Windows host running this test. Thus the test is skipped on
+	// this platform to guarantee consistent results.
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	var tmpDir, err = os.MkdirTemp("", "TestMaybeDelegateToOsAndArchSpecificWrapper")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	osName, err := platforms.DetermineOperatingSystem()
+	if err != nil {
+		log.Fatal(err)
+	}
+	arch, err := platforms.DetermineArchitecture(osName, platforms.DarwinArm64MinVersion)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
+	os.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
+	os.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
+
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
+	os.WriteFile(filepath.Join(tmpDir, "tools", "bazel."+runtime.GOOS+"-"+arch), []byte(""), 0700)
+	// Also create the standard wrapper to ensure we prefer the os/arch-specific wrapper.
+	os.WriteFile(filepath.Join(tmpDir, "tools", "bazel"), []byte(""), 0700)
+	// Also create the plaform-specific wrapper to ensure we prefer the os/arch-specific wrapper.
+	os.WriteFile(filepath.Join(tmpDir, "tools", "bazel."+arch), []byte(""), 0700)
+
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
+	expected := filepath.Join(tmpDir, "tools", "bazel."+runtime.GOOS+"-"+arch)
+
+	if entrypoint != expected {
+		t.Fatalf("Expected to delegate bazel to %q, but got %q", expected, entrypoint)
+	}
+}
+
+func TestMaybeDelegateToArchSpecificWrapper(t *testing.T) {
+	// It's not guaranteed that `tools/bazel` is executable on the
+	// Windows host running this test. Thus the test is skipped on
+	// this platform to guarantee consistent results.
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	var tmpDir, err = os.MkdirTemp("", "TestMaybeDelegateToArchSpecificWrapper")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	osName, err := platforms.DetermineOperatingSystem()
+	if err != nil {
+		log.Fatal(err)
+	}
+	arch, err := platforms.DetermineArchitecture(osName, platforms.DarwinArm64MinVersion)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.MkdirAll(tmpDir, os.ModeDir|0700)
+	os.WriteFile(filepath.Join(tmpDir, "WORKSPACE"), []byte(""), 0600)
+	os.WriteFile(filepath.Join(tmpDir, "BUILD"), []byte(""), 0600)
+
+	os.MkdirAll(filepath.Join(tmpDir, "tools"), os.ModeDir|0700)
+	os.WriteFile(filepath.Join(tmpDir, "tools", "bazel."+arch), []byte(""), 0700)
+	// Also create the standard wrapper to ensure we prefer the arch-specific wrapper.
+	os.WriteFile(filepath.Join(tmpDir, "tools", "bazel"), []byte(""), 0700)
+
+	entrypoint := maybeDelegateToWrapperFromDir("bazel_real", tmpDir, config.Null())
+	expected := filepath.Join(tmpDir, "tools", "bazel."+arch)
 
 	if entrypoint != expected {
 		t.Fatalf("Expected to delegate bazel to %q, but got %q", expected, entrypoint)

--- a/platforms/platforms.go
+++ b/platforms/platforms.go
@@ -112,6 +112,9 @@ func DetermineBazelFilename(version string, includeSuffix bool, config config.Co
 	return fmt.Sprintf("%s-%s-%s-%s%s", flavor, version, osName, machineName, filenameSuffix), nil
 }
 
+// DarwinArm64MinVersion represents the minimum Darwin version that supported arm64.
+const DarwinArm64MinVersion = "4.1.0"
+
 // DarwinFallback Darwin arm64 was supported since 4.1.0, before 4.1.0, fall back to x86_64
 func DarwinFallback(machineName string, version string) (alterMachineName string) {
 	// Do not use fallback for commits since they are likely newer than Bazel 4.1
@@ -124,7 +127,7 @@ func DarwinFallback(machineName string, version string) (alterMachineName string
 		return machineName
 	}
 
-	armSupportVer, _ := semver.NewVersion("4.1.0")
+	armSupportVer, _ := semver.NewVersion(DarwinArm64MinVersion)
 
 	if machineName == "arm64" && v.LessThan(armSupportVer) {
 		log.Printf("WARN: Fallback to x86_64 because arm64 is not supported on Apple Silicon until 4.1.0")


### PR DESCRIPTION
To do this, recognize new `tools/bazel.<OSNAME>-<ARCH>` and `tools/bazel.<ARCH>` names for the wrapper, and favor those over `tools/bazel` if they are present.