### PR TITLE
make release candidate versions handling on BAZELISK_BASE_URL consistent with github url

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -324,7 +324,7 @@ def determine_url(version, is_commit, bazel_filename):
 
     bazelisk_base_url = get_env_or_config("BAZELISK_BASE_URL")
     if bazelisk_base_url is not None:
-        return "{}/{}/{}".format(bazelisk_base_url, version, bazel_filename)
+        return "{}/{}{}/{}".format(bazelisk_base_url, version, rc if rc else "", bazel_filename)
     else:
         return "https://releases.bazel.build/{}/{}/{}".format(
             version, rc if rc else "release", bazel_filename


### PR DESCRIPTION
[The README](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#where-does-bazelisk-get-bazel-from) states:
> Bazelisk will then append `/<VERSION>/<FILENAME>` to the base URL instead of using the official release server.

`<VERSION>` typically includes the release candidate, e.g. `8.4.1rc2`. But currently, it only appends `8.4.1` without the `rc2`.

This PR fixes this to `8.4.1rc2`. It also make this more consistent with the github.com release urls, to make mirroring the github release urls simpler. This is a non-backwards compatible change, so we may want to introduce a new ENV var to prevent breakages with existing setups that are working.

If there's interest in this, I can leave add an environment variable to toggle it on, and leave it for V2 to turn it on by default.