### PR TITLE
Bump rules_shell from 0.4.1 to 0.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_go", version = "0.50.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "aspect_rules_js", version = "2.0.1")
-bazel_dep(name = "rules_shell", version = "0.4.1")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # In-direct deps, just to bump version
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.4", repo_name=None)


### PR DESCRIPTION
Should fix https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4962#019974c3-8efc-4852-8f2d-04dc4f87a524