### PR TITLE
Add BAZELISK_BASE_URL regression test

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -224,6 +224,19 @@ function test_bazel_version_from_base_url() {
       (echo "FAIL: Expected to find 'Build label: 7.2.1' in the output of 'bazelisk version'"; exit 1)
 }
 
+function test_bazel_version_rc_from_base_url() {
+  setup
+
+  echo "9.0.0rc1" > .bazelversion
+
+  BAZELISK_BASE_URL="https://github.com/bazelbuild/bazel/releases/download" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+          bazelisk version 2>&1 | tee log
+
+  grep "Build label: 9.0.0rc1" log || \
+      (echo "FAIL: Expected to find 'Build label: 9.0.0rc1' in the output of 'bazelisk version'"; exit 1)
+}
+
 function test_bazel_latest_minus_3_py() {
   setup
 
@@ -533,6 +546,9 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
   echo "# test_bazel_version_from_base_url"
   test_bazel_version_from_base_url
   echo
+
+  echo "# test_bazel_version_rc_from_base_url"
+  test_bazel_version_rc_from_base_url
 
   echo "# test_bazel_version_from_user_home_bazeliskrc"
   test_bazel_version_from_user_home_bazeliskrc


### PR DESCRIPTION
This is a test for ea3fa7db (#722), to confirm that go and py code agree on what the environment variable does.

The recently-changed python semantics were already what go was doing, so the fix is good, just lacked a test.  FYI @chrisirhc @fweikert.
