### PR TITLE
Introduce `bazeliskVersion` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ require users update their bazel.
 [shell wrapper script]: https://github.com/bazelbuild/bazel/blob/master/scripts/packages/bazel.sh
 ## Other features
 
-The Go version of Bazelisk offers three new flags.
+The Go version of Bazelisk offers the following new flags and commands:
 
 ### --strict
 
@@ -160,6 +160,14 @@ bazelisk --bisect=~6.0.0..HEAD test //foo:bar_test
 ```
 
 Note that, Bazelisk uses prebuilt Bazel binaries at commits on the main and release branches, therefore you cannot bisect your local commits.
+
+### bazeliskVersion
+
+`bazeliskVersion` prints the version of Bazelisk itself.
+
+```shell
+bazelisk bazeliskVersion
+```
 
 ### Command-line completion
 

--- a/core/core.go
+++ b/core/core.go
@@ -101,6 +101,12 @@ func RunBazeliskWithArgsFuncAndConfig(argsFunc ArgsFunc, repos *Repositories, co
 func RunBazeliskWithArgsFuncAndConfigAndOut(argsFunc ArgsFunc, repos *Repositories, config config.Config, out io.Writer) (int, error) {
 	httputil.UserAgent = getUserAgent(config)
 
+	// bazeliskVersion command must be the only argument
+	if len(os.Args[1:]) == 1 && os.Args[1] == "bazeliskVersion" {
+		printBazeliskVersion(false)
+		return 0, nil
+	}
+
 	bazelInstallation, err := GetBazelInstallation(repos, config)
 	if err != nil {
 		return -1, err
@@ -160,11 +166,7 @@ func RunBazeliskWithArgsFuncAndConfigAndOut(argsFunc ArgsFunc, repos *Repositori
 	// print bazelisk version information if "version" is the first non-flag argument
 	// bazel version is executed after this command
 	if ok, gnuFormat := isVersionCommand(args); ok {
-		if gnuFormat {
-			fmt.Printf("Bazelisk %s\n", BazeliskVersion)
-		} else {
-			fmt.Printf("Bazelisk version: %s\n", BazeliskVersion)
-		}
+		printBazeliskVersion(gnuFormat)
 	}
 
 	// handle completion command
@@ -203,6 +205,14 @@ func isVersionCommand(args []string) (result bool, gnuFormat bool) {
 		}
 	}
 	return
+}
+
+func printBazeliskVersion(gnuFormat bool) {
+	if gnuFormat {
+		fmt.Printf("Bazelisk %s\n", BazeliskVersion)
+	} else {
+		fmt.Printf("Bazelisk version: %s\n", BazeliskVersion)
+	}
 }
 
 // BazelInstallation provides a summary of a single install of `bazel`


### PR DESCRIPTION
Currently, bazelisk supports `version` command which is shared with Bazel itself. During the handling of this command, bazelisk prints its version and forwards the command line further to Bazel (downloading it if it's not already downloaded).

As described in issues #137 and #440, there are scenarios when users are only interested in the bazelisk version, and don't want to download and run Bazel as a side effect.

For such scenarios, I suggest adding a separate command. It allows us to preserve the current behavior and to keep bazelisk being a transparent wrapper around Bazel, and at the same time provide a functionality for those who need it.

---

Fix #137 and #440.