### PR TITLE
feat: support platform-specific SHA256 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ Note: `last_downstream_green` support has been removed, please use `last_green` 
 
 ## Where does Bazelisk get Bazel from?
 
-By default Bazelisk retrieves Bazel releases, release candidates and binaries built at green commits from Google Cloud Storage. The downloaded artifacts are validated against the SHA256 value recorded in `BAZELISK_VERIFY_SHA256` if this variable is set in the configuration file.
+By default Bazelisk retrieves Bazel releases, release candidates and binaries built at green commits from Google Cloud Storage. The downloaded artifacts can be validated against an expected SHA256 hash.
+
+Since each platform has a different binary with a different hash, Bazelisk supports platform-specific hash variables:
+
+- `BAZELISK_VERIFY_SHA256_<OS>_<ARCH>` - hash for a specific platform (e.g., `BAZELISK_VERIFY_SHA256_LINUX_X86_64`)
+- `BAZELISK_VERIFY_SHA256_NOJDK_<OS>_<ARCH>` - hash for nojdk builds (when `BAZELISK_NOJDK` is enabled)
+- `BAZELISK_VERIFY_SHA256` - fallback used when no platform-specific hash is set
 
 As mentioned in the previous section, the `<FORK>/<VERSION>` version format allows you to use your own Bazel fork hosted on GitHub:
 
@@ -270,6 +276,8 @@ The following variables can be set:
 - `BAZELISK_SKIP_WRAPPER`
 - `BAZELISK_USER_AGENT`
 - `BAZELISK_VERIFY_SHA256`
+- `BAZELISK_VERIFY_SHA256_<OS>_<ARCH>` (e.g., `BAZELISK_VERIFY_SHA256_DARWIN_ARM64`)
+- `BAZELISK_VERIFY_SHA256_NOJDK_<OS>_<ARCH>` (e.g., `BAZELISK_VERIFY_SHA256_NOJDK_LINUX_X86_64`)
 - `USE_BAZEL_VERSION`
 
 Configuration variables are evaluated with precedence order. The preferred values are derived in order from highest to lowest precedence as follows:
@@ -278,7 +286,7 @@ Configuration variables are evaluated with precedence order. The preferred value
 * Variables defined in the workspace root `.bazeliskrc`
 * Variables defined in the user home `.bazeliskrc`
 
-Additionally, the Bazelisk home directory is also evaluated in precedence order. The preferred value is OS-specific e.g. `BAZELISK_HOME_LINUX`, then we fall back to `BAZELISK_HOME`.
+Some variables support platform-specific variants. For example, `BAZELISK_HOME_LINUX` takes precedence over `BAZELISK_HOME`, and `BAZELISK_VERIFY_SHA256_DARWIN_ARM64` takes precedence over `BAZELISK_VERIFY_SHA256`.
 
 ## Requirements
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -463,6 +463,78 @@ function test_bazel_verify_sha256() {
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
+function test_bazel_verify_sha256_platform_specific() {
+  setup
+
+  echo "9.0.0" > .bazelversion
+
+  local os="$(uname -s | tr A-Z a-z)"
+  local arch="$(uname -m)"
+
+  # Map to bazelisk naming convention
+  case "${arch}" in
+    x86_64|amd64)
+      arch="X86_64"
+      ;;
+    arm64|aarch64)
+      arch="ARM64"
+      ;;
+  esac
+
+  # SHA256 hashes for Bazel 9.0.0 binaries.
+  # Mixed case is intentional to test hash normalization.
+  case "${os}" in
+    darwin)
+      os_upper="DARWIN"
+      if [[ "${arch}" == "ARM64" ]]; then
+        expected_sha256="2c3cce548a4b6a97A2A5267712187b784b52714c4a2b0613e7386b15669d783c"
+      else
+        expected_sha256="aa7e5fc364eaaba7f4f271dbf8c14172a5433f663cca6b130325df4b6569b3f0"
+      fi
+      ;;
+    linux)
+      os_upper="LINUX"
+      if [[ "${arch}" == "ARM64" ]]; then
+        expected_sha256="cab23c59d3d39c5E5382F12cd116b47445afdff9813516c18ae3ee8836b3037f"
+      else
+        expected_sha256="C44A93f25398c68f904fa1d19b61d321de6c0d2f09dca375d7bc0dc9b9428403"
+      fi
+      ;;
+    msys*|mingw*|cygwin*)
+      os_upper="WINDOWS"
+      if [[ "${arch}" == "ARM64" ]]; then
+        expected_sha256="ab3db0b1f129436180927Baa0f1f38e6d86a88fc9ee802572a76c9519a06f550"
+      else
+        expected_sha256="463faee497df2913854D80776784137cb47f42960b4ef4e4f85068c8da4849a8"
+      fi
+      ;;
+    *)
+      echo "FAIL: Unknown OS ${os} in test"
+      exit 1
+      ;;
+  esac
+
+  local platform_var="BAZELISK_VERIFY_SHA256_${os_upper}_${arch}"
+
+  # Test 1: Platform-specific variable should work
+  env BAZELISK_HOME="$BAZELISK_HOME" "${platform_var}=${expected_sha256}" \
+      bazelisk version 2>&1 | tee log
+
+  grep "Build label:" log || \
+      (echo "FAIL: Expected to find 'Build label' with platform-specific hash"; exit 1)
+
+  # Test 2: Platform-specific should take precedence over generic
+  rm -rf "$BAZELISK_HOME/downloads"
+
+  env BAZELISK_HOME="$BAZELISK_HOME" \
+      BAZELISK_VERIFY_SHA256="wrong-generic-hash" \
+      "${platform_var}=${expected_sha256}" \
+      bazelisk version 2>&1 | tee log
+
+  grep "Build label:" log || \
+      (echo "FAIL: Platform-specific should take precedence over generic"; exit 1)
+}
+
 function test_bazel_download_path_py() {
   setup
 
@@ -583,6 +655,10 @@ if [[ $BAZELISK_VERSION == "GO" ]]; then
 
   echo '# test_bazel_verify_sha256'
   test_bazel_verify_sha256
+  echo
+
+  echo '# test_bazel_verify_sha256_platform_specific'
+  test_bazel_verify_sha256_platform_specific
   echo
 
   echo "# test_bazel_prepend_binary_directory_to_path_go"

--- a/core/core.go
+++ b/core/core.go
@@ -503,11 +503,17 @@ func downloadBazel(bazelVersionString string, bazeliskHome string, repos *Reposi
 //	downloads/metadata/[fork-or-url]/bazel-[version-os-etc] is a text file containing a hex sha256 of the contents of the downloaded bazel file.
 //	downloads/sha256/[sha256]/bin/bazel[extension] contains the bazel with a particular sha256.
 func downloadBazelIfNecessary(version string, bazeliskHome string, bazelForkOrURLDirName string, repos *Repositories, config config.Config, downloader DownloadFunc) (string, error) {
-	pathSegment, err := platforms.DetermineBazelFilename(version, false, config)
+	osName, err := platforms.DetermineOperatingSystem()
 	if err != nil {
-		return "", fmt.Errorf("could not determine path segment to use for Bazel binary: %v", err)
+		return "", fmt.Errorf("could not determine operating system: %v", err)
 	}
+	arch, err := platforms.DetermineArchitecture(osName, version)
+	if err != nil {
+		return "", fmt.Errorf("could not determine architecture: %v", err)
+	}
+	isNojdk := platforms.IsNojdkEnabled(config)
 
+	pathSegment := platforms.FormatBazelFilename(version, false, osName, arch, isNojdk)
 	destFile := "bazel" + platforms.DetermineExecutableFilenameSuffix()
 
 	mappingPath := filepath.Join(bazeliskHome, "downloads", "metadata", bazelForkOrURLDirName, pathSegment)
@@ -524,7 +530,7 @@ func downloadBazelIfNecessary(version string, bazeliskHome string, bazelForkOrUR
 		return "", fmt.Errorf("failed to download bazel: %w", err)
 	}
 
-	expectedSha256 := strings.ToLower(config.Get("BAZELISK_VERIFY_SHA256"))
+	expectedSha256 := getExpectedSHA256(config, osName, arch, isNojdk)
 	if len(expectedSha256) > 0 {
 		if expectedSha256 != downloadedDigest {
 			return "", fmt.Errorf("%s has sha256=%s but need sha256=%s", pathToBazelInCAS, downloadedDigest, expectedSha256)
@@ -1561,4 +1567,22 @@ func extractCompletionScriptsFromZip(zipData []byte) (map[string]string, error) 
 	// Fish completion is optional (older Bazel versions might not have it)
 
 	return completionScripts, nil
+}
+
+// getExpectedSHA256 returns the expected SHA256 hash for verification.
+// It checks platform-specific keys first, then falls back to the generic key.
+// Returns empty string if no hash is configured.
+// TODO(#767): Normalize hash values at the config layer to avoid repetitive ToLower calls.
+func getExpectedSHA256(cfg config.Config, osName, arch string, nojdk bool) string {
+	suffix := strings.ToUpper(osName) + "_" + strings.ToUpper(arch)
+
+	if nojdk {
+		if hash := cfg.Get("BAZELISK_VERIFY_SHA256_NOJDK_" + suffix); hash != "" {
+			return strings.ToLower(hash)
+		}
+	}
+	if hash := cfg.Get("BAZELISK_VERIFY_SHA256_" + suffix); hash != "" {
+		return strings.ToLower(hash)
+	}
+	return strings.ToLower(cfg.Get("BAZELISK_VERIFY_SHA256"))
 }

--- a/platforms/platforms_test.go
+++ b/platforms/platforms_test.go
@@ -2,6 +2,46 @@ package platforms
 
 import "testing"
 
+func TestFormatBazelFilename(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		includeSuffix bool
+		osName        string
+		machineName   string
+		nojdk         bool
+		want          string
+	}{
+		{
+			name:          "standard bazel binary",
+			version:       "7.1.1",
+			includeSuffix: false,
+			osName:        "linux",
+			machineName:   "x86_64",
+			nojdk:         false,
+			want:          "bazel-7.1.1-linux-x86_64",
+		},
+		{
+			name:          "nojdk binary",
+			version:       "7.1.1",
+			includeSuffix: false,
+			osName:        "linux",
+			machineName:   "x86_64",
+			nojdk:         true,
+			want:          "bazel_nojdk-7.1.1-linux-x86_64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatBazelFilename(tt.version, tt.includeSuffix, tt.osName, tt.machineName, tt.nojdk)
+			if got != tt.want {
+				t.Errorf("FormatBazelFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDarwinFallback(t *testing.T) {
 	type args struct {
 		machineName string


### PR DESCRIPTION
Adds support for platform-specific `BAZELISK_VERIFY_SHA256` variables, enabling SHA256 verification in multiplatform projects.

Fixes #522

## Problem

The current `BAZELISK_VERIFY_SHA256` only accepts a single hash value, but Bazel binaries have different SHA256 hashes per platform. Projects building on multiple platforms cannot use SHA256 verification.

## Solution

Since each platform has a different binary with a different hash, Bazelisk now supports platform-specific hash variables:

- `BAZELISK_VERIFY_SHA256_<OS>_<ARCH>` - hash for a specific platform (e.g., `BAZELISK_VERIFY_SHA256_LINUX_X86_64`)
- `BAZELISK_VERIFY_SHA256_NOJDK_<OS>_<ARCH>` - hash for nojdk builds (when `BAZELISK_NOJDK` is enabled)
- `BAZELISK_VERIFY_SHA256` - fallback used when no platform-specific hash is set

### Supported Platforms

| OS | Architectures |
|----|---------------|
| `DARWIN` | `ARM64`, `X86_64` |
| `LINUX` | `ARM64`, `X86_64` |
| `WINDOWS` | `ARM64`, `X86_64` |

### Example `.bazeliskrc`

```ini
BAZELISK_VERIFY_SHA256_DARWIN_ARM64=2c3cce548a4b6a97a2a5267712187b784b52714c4a2b0613e7386b15669d783c
BAZELISK_VERIFY_SHA256_DARWIN_X86_64=aa7e5fc364eaaba7f4f271dbf8c14172a5433f663cca6b130325df4b6569b3f0
BAZELISK_VERIFY_SHA256_LINUX_X86_64=c44a93f25398c68f904fa1d19b61d321de6c0d2f09dca375d7bc0dc9b9428403
BAZELISK_VERIFY_SHA256_LINUX_ARM64=cab23c59d3d39c5e5382f12cd116b47445afdff9813516c18ae3ee8836b3037f
BAZELISK_VERIFY_SHA256_WINDOWS_X86_64=463faee497df2913854d80776784137cb47f42960b4ef4e4f85068c8da4849a8
BAZELISK_VERIFY_SHA256_WINDOWS_ARM64=ab3db0b1f129436180927baa0f1f38e6d86a88fc9ee802572a76c9519a06f550
```

## Implementation Notes

- Refactored `downloadBazelIfNecessary` to compute platform info once upfront
- Added `FormatBazelFilename` helper in `platforms` package
- Hash normalized to lowercase once at return (SHA256 hex is case-insensitive)
- Full backward compatibility with existing `BAZELISK_VERIFY_SHA256`

## Test Plan

- [x] Unit tests for `getExpectedSHA256` (7 focused tests)
- [x] Unit tests for `FormatBazelFilename` (2 tests)
- [x] Shell integration test with Bazel 9.0.0 (all 6 platform/arch combinations)
- [x] All existing tests pass