### PR TITLE
Replace flaky SourceForge mirror with GitHub Releases

### DIFF
--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -365,8 +365,8 @@ EOF
   BAZELISK_HOME="$BAZELISK_HOME" bazelisk clean --expunge 2>&1
 
   # We need a separate mirror of bazel binaries, which has identical files.
-  # Ideally we wouldn't depend on sourceforge for test runtime, but hey, it exists and it works.
-  BAZELISK_HOME="$BAZELISK_HOME" BAZELISK_BASE_URL=https://downloads.sourceforge.net/project/bazel.mirror bazelisk fetch --repo=@print_path 2>&1 | tee log2
+  # We use GitHub releases as a separate mirror from the GCS default.
+  BAZELISK_HOME="$BAZELISK_HOME" BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download bazelisk fetch --repo=@print_path 2>&1 | tee log2
 
   path1="$(grep "PATH is:" log1)"
   path2="$(grep "PATH is:" log2)"


### PR DESCRIPTION
Bazelisk started failing since last Saturday: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/5403#019d8a36-dec5-4a35-bba8-3a058264e8ec.

Note that this doesn't only fail for Bazel@Head, but also for Bazel 9 since it seems that SourceForge is missing assets (not an error related to Bazel@Head).

This commit updates the secondary mirror URL to `https://github.com/bazelbuild/bazel/releases/download`,
providing identical assets with a better reliability on GitHub.